### PR TITLE
fix: 보낸 메일함 UI, 로직 변경 수정

### DIFF
--- a/design-system/ui/textFields/MultilineTextField.tsx
+++ b/design-system/ui/textFields/MultilineTextField.tsx
@@ -15,7 +15,7 @@ const MultilineTextField = forwardRef<HTMLTextAreaElement, MultilineTextFieldPro
   ({ label, detail, value, onChange, onKeyDown, disabled = false, placeholder = '', className = '', ...rest }, ref) => {
     return (
       <div className={`${className}`}>
-        <label className="block px-1 font-semibold text-gray-700 text-base lg:text-lg md:mb-2">{label}</label>
+        <label className="block px-1 font-semibold text-base lg:text-lg md:mb-2">{label}</label>
         <label className="block px-1 mb-1 font-medium text-placeholderText sm:text-10 md:text-13 lg:text-13">
           {detail}
         </label>

--- a/src/features/dashboard/ui/EmailInput.tsx
+++ b/src/features/dashboard/ui/EmailInput.tsx
@@ -47,9 +47,9 @@ const EmailInput = ({ type = '이메일 예약 발송', openSelectTicket, allPar
       </div>
       {/* 이메일 내용 작성 부분 */}
       <MultilineTextField
-        label="추가 발송될 이메일 내용"
+        label="발송될 이메일 내용"
         className="h-80 md:mb-4"
-        placeholder="추가 발송될 이메일 본문 내용입니다."
+        placeholder="발송될 이메일 본문 내용입니다."
       />
     </div>
   );

--- a/src/pages/dashboard/ui/mail/MailBoxPage.tsx
+++ b/src/pages/dashboard/ui/mail/MailBoxPage.tsx
@@ -7,10 +7,11 @@ import { mailInfo } from '../../../../shared/types/mailInfoType';
 import EmailDeleteMoal from '../../../../widgets/dashboard/ui/EmailDeleteModal';
 
 const MailBoxPage = () => {
-  const [listType, setListType] = useState<'all' | 'pending'>('all');
+  const [listType, setListType] = useState<'completed' | 'pending'>('completed');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const currentDate = new Date();
 
+  const completedMails = mailInfo.filter(mail => new Date(mail.date) < currentDate);
   const pendingMails = mailInfo.filter(mail => new Date(mail.date) > currentDate);
 
   return (
@@ -22,9 +23,9 @@ const MailBoxPage = () => {
         </div>
         <div className="flex gap-3 font-semibold text-15">
           <TextButton
-            label="모든 메일"
-            onClick={() => setListType('all')}
-            className={listType === 'all' ? 'text-main' : ''}
+            label="발송 예약 메일"
+            onClick={() => setListType('completed')}
+            className={listType === 'completed' ? 'text-main' : ''}
           />
           <TextButton
             label="미발송 예약 메일"
@@ -32,7 +33,7 @@ const MailBoxPage = () => {
             className={listType === 'pending' ? 'text-main' : ''}
           />
         </div>
-        {(listType === 'all' ? mailInfo : pendingMails).map(mail => (
+        {(listType === 'completed' ? completedMails : pendingMails).map(mail => (
           <SentMailCard
             key={mail.id}
             mail={mail}


### PR DESCRIPTION
### 발송된 메일과 미발송 메일 버튼으로 필터링되도록 디자인 변경
![스크린샷 2025-03-11 오전 12 03 36](https://github.com/user-attachments/assets/a51c4c32-c169-49c2-aff1-94ed60c54f95)

![스크린샷 2025-03-11 오전 12 03 42](https://github.com/user-attachments/assets/dd53eefa-35e6-4512-8880-aa0a28513428)

### label 이름 변경(추가 발송될 이메일 내용 -> 발송될 이메일 내용)
![image](https://github.com/user-attachments/assets/a8f94921-5338-41a1-93d3-1d7961e8e3c4)
