### PR TITLE
feat: 이벤트 상세 페이지 API 연동

### DIFF
--- a/design-system/ui/modals/QrModal.tsx
+++ b/design-system/ui/modals/QrModal.tsx
@@ -68,19 +68,19 @@ const QrModal = ({
           <div className="space-y-1 text-deDayTextDark">
             <IconText
               size="xSmall"
-              iconPath={<img src={qr_calendar} alt="qr_calendar" />}
+              iconPath={<img src={qr_calendar} alt="qr_calendar" className='mr-1'/>}
               children={formattedDate}
               className="text-11"
             ></IconText>
             <IconText
               size="xSmall"
-              iconPath={<img src={qr_location} alt="qr_location" />}
+              iconPath={<img src={qr_location} alt="qr_location" className='mr-1'/>}
               children={location}
               className="text-11"
             ></IconText>
             <IconText
               size="xSmall"
-              iconPath={<img src={qr_ticket} alt="qr_ticket" />}
+              iconPath={<img src={qr_ticket} alt="qr_ticket" className='mr-1'/>}
               children={ticketName}
               className="text-11"
             ></IconText>
@@ -88,13 +88,13 @@ const QrModal = ({
             <hr />
             <IconText
               size="xSmall"
-              iconPath={<img src={qr_check} alt="qr_check" />}
+              iconPath={<img src={qr_check} alt="qr_check" className='mr-1'/>}
               children={orderStatus === 'COMPLETED' ? '승인됨' : '대기 중'}
               className="text-11"
             ></IconText>
             <IconText
               size="xSmall"
-              iconPath={<img src={qr_check} alt="qr_check" />}
+              iconPath={<img src={qr_check} alt="qr_check" className='mr-1'/>}
               children={isCheckIn ? '체크인 완료' : '체크인 미완료'}
               className="text-11"
             ></IconText>

--- a/src/features/event-manage/event-create/api/event.ts
+++ b/src/features/event-manage/event-create/api/event.ts
@@ -5,3 +5,8 @@ export const createEvent = async (data: CreateEventRequest) => {
   const response = await axiosClient.post('/events', data);
   return response.data;
 };
+
+export const readEventDetail = async (eventId: number) => {
+  const response = await axiosClient.get(`/events/${eventId}`);
+  return response.data;
+};

--- a/src/features/ticket/api/order.ts
+++ b/src/features/ticket/api/order.ts
@@ -1,14 +1,9 @@
 import { axiosClient } from "../../../shared/types/api/http-client"
 export const readMyTickets = {
-    get: async (page: number = 0, size: number = 10) => {
-        try {
-          const response = await axiosClient.get("/orders", {
-            params: { page, size },
-          });
-          return response.data;
-        } catch (error) {
-          console.error("티켓 조회 중 오류 발생:", error);
-          throw error;
-        }
-      },
+  get: async (page: number = 0, size: number = 10) => {
+    const response = await axiosClient.get("/orders", {
+      params: { page, size },
+    });
+    return response.data;
+  },
 }

--- a/src/pages/event/ui/EventDetailsPage.tsx
+++ b/src/pages/event/ui/EventDetailsPage.tsx
@@ -1,23 +1,52 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { eventData } from '../../../shared/types/eventDetailType';
 import OrganizerInfo from '../../../widgets/event/ui/OrganizerInfo';
 import Header from '../../../../design-system/ui/Header';
 import Search from '../../../../design-system/icons/Search.svg';
 import IconButton from '../../../../design-system/ui/buttons/IconButton';
-import banner from '../../../../public/assets/banners/1.png';
 import share from '../../../../public/assets/event-manage/details/Share.svg';
 import like from '../../../../public/assets/event-manage/details/Like.svg';
 import liked from '../../../../public/assets/event-manage/details/ClickedLike.svg';
 import TicketInfo from '../../../widgets/event/ui/TicketInfo';
 import link from '../../../../public/assets/event-manage/details/Link.svg';
 import ShareEventModal from '../../../features/event-manage/event-create/ui/ShareEventModal';
+import { readEventDetail } from '../../../features/event-manage/event-create/api/event';
+import participantsImg from '../../../../public/assets/event-manage/details/People.svg';
+import dateImg from '../../../../public/assets/event-manage/details/Date.svg';
+import timeImg from '../../../../public/assets/event-manage/details/Time.svg';
+import locationImg from '../../../../public/assets/event-manage/details/Location.svg';
+
+interface ReadEvent {
+  id: number;
+  bannerImageUrl: string;
+  title: string;
+  participantCount: number;
+  startDate: string;
+  endDate: string;
+  startTime: string;
+  endTime: string;
+  address: string;
+  location: { lat: number; lng: number };
+  description: string;
+  hostChannelName: string;
+  hostChannelDescription: string;
+  organizerEmail: string;
+  organizerPhoneNumber: string;
+  referenceLinks: { title: string; url: string };
+  category: string;
+  onlineType: string;
+  status: string;
+  hashtags: string[];
+}
 
 const EventDetailsPage = () => {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [clickedLike, setClickedLike] = useState(false);
+
+  const [event, setEvent] = useState<ReadEvent | null>(null);
+  const eventId = 1; //수정 필요
 
   const handleShareClick = (title: string) => {
     setTitle(title);
@@ -38,6 +67,19 @@ const EventDetailsPage = () => {
     }
   }, [isModalOpen]);
 
+  useEffect(() => {
+    const fetchEventDetail = async () => {
+      try {
+        const response = await readEventDetail(eventId);
+        setEvent(response.result);
+      } catch (error) {
+        console.error('이벤트 상세 정보 불러오기 실패:', error);
+      }
+    };
+    fetchEventDetail();
+  }, []);
+
+
   return (
     <>
       <Header
@@ -47,17 +89,18 @@ const EventDetailsPage = () => {
         centerContent="같이가요"
         rightContent={<img src={Search} alt="검색" className="w-4" />}
       />
+      {event ? (
       <>
-        <img src={banner} alt="이벤트 배너" className="w-full h-64 mb-6" />
+        <img src={event.bannerImageUrl} alt="이벤트 배너" className="w-full h-64 mb-6" />
         <div className="flex flex-col gap-3 px-4 md:px-6">
-          {eventData.map(event => (
+          
             <div key={event.id} className="flex flex-col gap-2">
               <h1 className="text-xl md:text-2xl font-bold">{event.title}</h1>
               <div className="flex justify-between items-center gap-1">
                 <div className="flex gap-2">
-                  <img src={event.participantsImg} alt="인원수 이미지" />
+                  <img src={participantsImg} alt="인원수 이미지" />
                   <span className="font-bold text-base md:text-lg py-2">
-                    현재 {event.participants}명이 참가 신청했습니다.
+                    현재 {event.participantCount}명이 참가 신청했습니다.
                   </span>
                 </div>
                 <div className="flex gap-3">
@@ -72,28 +115,33 @@ const EventDetailsPage = () => {
                 </div>
               </div>
               <div className="flex gap-2">
-                <img src={event.dateImg} alt="달력 이미지" />
-                <span className="text-sm md:text-base">{event.date}</span>
+                <img src={dateImg} alt="달력 이미지" />
+                <span className="text-sm md:text-base">{event.startDate} ~ {event.endDate}</span>
               </div>
               <div className="flex gap-2">
-                <img src={event.timeImg} alt="시간 이미지" />
-                <span className="text-sm md:text-base">{event.time}</span>
+                <img src={timeImg} alt="시간 이미지" />
+                <span className="text-sm md:text-base">{event.startTime} ~ {event.endTime}</span>
               </div>
               <div className="flex gap-2">
-                <img src={event.locationImg} alt="위치 이미지" />
-                <span className="text-sm md:text-base">{event.location}</span>
+                <img src={locationImg} alt="위치 이미지" />
+                <span className="text-sm md:text-base">{event.address}</span>
               </div>
-              <span className="text-sm md:text-base py-3">{event.detail}</span>
+              <span className="text-sm md:text-base py-3">{event.description}</span>
             </div>
-          ))}
+         
 
           <h2 className="font-bold text-xl">위치</h2>
           <div className="w-full h-48 bg-gray2" />
 
-          <OrganizerInfo />
+          <OrganizerInfo
+              name={event.hostChannelName}
+              description={event.hostChannelDescription}
+              phone={event.organizerPhoneNumber}
+              email={event.organizerEmail}
+            />
 
           <h2 className="font-bold text-xl">티켓 옵션</h2>
-          <TicketInfo />
+          <TicketInfo eventId={event.id}/>
 
           <div className="flex flex-col gap-2">
             <h2 className="font-bold text-xl">관련 링크</h2>
@@ -104,6 +152,9 @@ const EventDetailsPage = () => {
           </div>
         </div>
       </>
+      ) : (
+        <div className="flex justify-center items-center h-screen">로딩 중...</div>
+      )}
       {isModalOpen && <ShareEventModal closeModal={closeModal} eventName={title} />}
     </>
   );

--- a/src/pages/event/ui/EventDetailsPage.tsx
+++ b/src/pages/event/ui/EventDetailsPage.tsx
@@ -15,6 +15,7 @@ import participantsImg from '../../../../public/assets/event-manage/details/Peop
 import dateImg from '../../../../public/assets/event-manage/details/Date.svg';
 import timeImg from '../../../../public/assets/event-manage/details/Time.svg';
 import locationImg from '../../../../public/assets/event-manage/details/Location.svg';
+import KakaoMap from '../../../shared/ui/KakaoMap';
 
 interface ReadEvent {
   id: number;
@@ -90,10 +91,10 @@ const EventDetailsPage = () => {
         rightContent={<img src={Search} alt="검색" className="w-4" />}
       />
       {event ? (
-      <>
-        <img src={event.bannerImageUrl} alt="이벤트 배너" className="w-full h-64 mb-6" />
-        <div className="flex flex-col gap-3 px-4 md:px-6">
-          
+        <>
+          <img src={event.bannerImageUrl} alt="이벤트 배너" className="w-full h-64 mb-6" />
+          <div className="flex flex-col gap-3 px-4 md:px-6">
+
             <div key={event.id} className="flex flex-col gap-2">
               <h1 className="text-xl md:text-2xl font-bold">{event.title}</h1>
               <div className="flex justify-between items-center gap-1">
@@ -128,30 +129,30 @@ const EventDetailsPage = () => {
               </div>
               <span className="text-sm md:text-base py-3">{event.description}</span>
             </div>
-         
 
-          <h2 className="font-bold text-xl">위치</h2>
-          <div className="w-full h-48 bg-gray2" />
 
-          <OrganizerInfo
+            <h2 className="font-bold text-xl">위치</h2>
+            <KakaoMap lat={event.location.lat} lng={event.location.lng} />
+
+            <OrganizerInfo
               name={event.hostChannelName}
               description={event.hostChannelDescription}
               phone={event.organizerPhoneNumber}
               email={event.organizerEmail}
             />
 
-          <h2 className="font-bold text-xl">티켓 옵션</h2>
-          <TicketInfo eventId={event.id}/>
+            <h2 className="font-bold text-xl">티켓 옵션</h2>
+            <TicketInfo eventId={event.id} />
 
-          <div className="flex flex-col gap-2">
-            <h2 className="font-bold text-xl">관련 링크</h2>
-            <div className="flex items-center gap-3 mb-4">
-              <img src={link} alt="링크 이모지" />
-              <span>공식 웹사이트</span>
+            <div className="flex flex-col gap-2">
+              <h2 className="font-bold text-xl">관련 링크</h2>
+              <div className="flex items-center gap-3 mb-4">
+                <img src={link} alt="링크 이모지" />
+                <span>공식 웹사이트</span>
+              </div>
             </div>
           </div>
-        </div>
-      </>
+        </>
       ) : (
         <div className="flex justify-center items-center h-screen">로딩 중...</div>
       )}

--- a/src/pages/menu/ui/MyTicketPage.tsx
+++ b/src/pages/menu/ui/MyTicketPage.tsx
@@ -11,19 +11,22 @@ import ticketImg from '../../../../public/assets/menu/Ticket.svg';
 
 type Ticket = {
   id: number;
-  eventId: number;
-  bannerImageUrl: string;
-  title: string;
-  hostChannelName: string;
-  address: string;
-  startDate: string;
-  ticketName: string;
-  orderStatus: "COMPLETED" | "PENDING" | "CANCELED";
-  remainDays: string;
-  ticketPrice: number;
+  event: {
+    id: number;
+    bannerImageUrl: string;
+    title: string;
+    hostChannelName: string;
+    address: string;
+    startDate: string;
+    remainDays: string;
+    hashtags: string[];
+    onlineType: "ONLINE" | "OFFLINE"; // onlineType 추가
+  };
   ticketQrCode: string;
+  ticketName: string;
+  ticketPrice: number;
+  orderStatus: "COMPLETED" | "PENDING" | "CANCELED";
   checkIn: boolean;
-  hashtags: [];
 };
 
 const MyTicketPage = () => {
@@ -36,6 +39,7 @@ const MyTicketPage = () => {
       try {
         const response = await readMyTickets.get(0, 10);
         setMyTickets(response.result || []);
+        console.log(response.result);
       } catch (error) {
         console.error("티켓 목록 불러오기 실패:", error);
       }
@@ -50,13 +54,13 @@ const MyTicketPage = () => {
         {myTickets.map((ticket, index) => (
           <EventCard
             key={index}
-            img={ticket.bannerImageUrl}
-            eventTitle={ticket.title}
-            dDay={ticket.remainDays}
-            host={ticket.hostChannelName}
-            eventDate={ticket.startDate}
-            location={ticket.address}
-            hashtags={ticket.hashtags}
+            img={ticket.event.bannerImageUrl}
+            eventTitle={ticket.event.title}
+            dDay={ticket.event.remainDays}
+            host={ticket.event.hostChannelName}
+            eventDate={ticket.event.startDate}
+            location={ticket.event.address}
+            hashtags={ticket.event.hashtags}
             onClick={() => {
               setSelectedTicket(ticket);
               setIsModalOpen(true);
@@ -86,16 +90,16 @@ const MyTicketPage = () => {
               isChecked={true}
               iconPath1={<img src={QRbackground} alt="QRbackground" />}
               ticketQrCode = {selectedTicket.ticketQrCode}
-              title={selectedTicket.title}
-              hostName={selectedTicket.hostChannelName}
-              date={selectedTicket.startDate}
-              location={selectedTicket.address}
+              title={selectedTicket.event.title}
+              hostName={selectedTicket.event.hostChannelName}
+              date={selectedTicket.event.startDate}
+              location={selectedTicket.event.address}
               ticketName={selectedTicket.ticketName}
               price={selectedTicket.ticketPrice}
               orderStatus={selectedTicket.orderStatus}
               isCheckIn={selectedTicket.checkIn}
               isCountdownChecked={true}
-              remainDays={selectedTicket.remainDays}
+              remainDays={selectedTicket.event.remainDays}
               onClick={() => setIsModalOpen(false)}
             />
           </div>

--- a/src/shared/ui/EventCard.tsx
+++ b/src/shared/ui/EventCard.tsx
@@ -50,7 +50,7 @@ const EventCard = ({ img, eventTitle, dDay, host, eventDate, location, hashtags,
         {children}
         {/* 해시태그 */}
         <div className="flex flex-wrap w-full h-6 mt-2 overflow-hidden text-xs font-semibold text-gray-700 whitespace-nowrap">
-          {hashtags.map((tag, index) => (
+          {(hashtags ?? []).map((tag, index) => (
             <span key={index} className="flex items-center justify-center h-6 px-2 mr-2 bg-gray-200 rounded last:mr-0">
               {tag}
             </span>

--- a/src/widgets/event/ui/OrganizerInfo.tsx
+++ b/src/widgets/event/ui/OrganizerInfo.tsx
@@ -1,21 +1,27 @@
-import { hostInfo } from '../../../shared/types/hostInfoType';
+import phoneImg from '../../../../public/assets/event-manage/details/Phone.svg';
+import emailImg from '../../../../public/assets/event-manage/details/Email.svg';
 
-const OrganizerInfo = () => {
-  const host = hostInfo.find(host => host.id === 1);
-  if (!host) return null;
+interface OrganizerInfoProps {
+  name: string;
+  description: string;
+  phone: string;
+  email: string;
+}
+
+const OrganizerInfo = ({ name, description, phone, email}: OrganizerInfoProps) => {
 
   return (
     <div className="flex flex-col w-full h-full bg-gray-100 px-4 py-3 md:px-6 md:py-4 rounded-[10px] gap-1">
       <h1 className="font-bold text-lg">주최자</h1>
-      <span className="font-semibold">{host.name}</span>
-      <span className="text-sm md:text-base">{host.description}</span>
+      <span className="font-semibold">{name}</span>
+      <span className="text-sm md:text-base">{description}</span>
       <div className="flex gap-3">
-        <img src={host.phoneImg} alt="번호 이미지" />
-        <span className="text-sm md:text-base">{host.phone}</span>
+        <img src={phoneImg} alt="번호 이미지" />
+        <span className="text-sm md:text-base">{phone}</span>
       </div>
       <div className="flex gap-3">
-        <img src={host.emailImg} alt="이메일 이미지" />
-        <span className="text-sm md:text-base">{host.email}</span>
+        <img src={emailImg} alt="이메일 이미지" />
+        <span className="text-sm md:text-base">{email}</span>
       </div>
     </div>
   );

--- a/src/widgets/event/ui/TicketInfo.tsx
+++ b/src/widgets/event/ui/TicketInfo.tsx
@@ -1,34 +1,57 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import TertiaryButton from '../../../../design-system/ui/buttons/TertiaryButton';
-import { TicketMockData } from '../../../shared/types/ticketType';
 import TextButton from '../../../../design-system/ui/buttons/TextButton';
+import { readTicket } from '../../../features/ticket/api/ticket';
+import { ReadTicket } from '../../../pages/dashboard/ui/ticket/TicketListPage';
 
-const TicketInfo = () => {
+const TicketInfo = ({ eventId }: { eventId: number }) => {
   const limitNum = 4;
-  const [quantity, setQuantity] = useState(
-    TicketMockData.reduce((acc, ticket) => {
-      acc[ticket.eventId] = 1;
-      return acc;
-    }, {} as { [key: string]: number })
-  );
+  const [tickets, setTickets] = useState<ReadTicket[]>([]);
+  const [quantity, setQuantity] = useState<{ [key: number]: number }>({});
 
-  const handleIncrement = (eventId: number) => {
+  useEffect(() => {
+    const fetchTickets = async () => {
+      try {
+        const data = await readTicket.getAll(eventId);
+        if (data.isSuccess && Array.isArray(data.result)) {
+          setTickets(data.result);
+        } else {
+          setTickets([]);
+        }
+      } catch (error) {
+        console.error("티켓 데이터를 불러오는 중 오류 발생:", error);
+        setTickets([]);
+      }
+    };
+    fetchTickets();
+  }, [eventId]);
+  useEffect(() => {
+    if (tickets.length > 0) {
+      const initialQuantity: { [key: number]: number } = {};
+      tickets.forEach(ticket => {
+        initialQuantity[ticket.ticketId] = 1;
+      });
+      setQuantity(initialQuantity);
+    }
+  }, [tickets]);
+  const handleIncrement = (ticketId: number) => {
     setQuantity(prev => ({
       ...prev,
-      [eventId]: prev[eventId] < limitNum ? prev[eventId] + 1 : prev[eventId],
+      [ticketId]: prev[ticketId] < limitNum ? prev[ticketId] + 1 : prev[ticketId],
     }));
   };
-  const handleDecrement = (eventId: number) => {
+
+  const handleDecrement = (ticketId: number) => {
     setQuantity(prev => ({
       ...prev,
-      [eventId]: prev[eventId] > 1 ? prev[eventId] - 1 : prev[eventId],
+      [ticketId]: prev[ticketId] > 1 ? prev[ticketId] - 1 : prev[ticketId],
     }));
   };
 
   return (
     <div className="w-full h-full">
-      {TicketMockData.map(ticket => (
-        <div key={ticket.eventId} className="bg-gray1 px-3 py-3 md:px-6 md:py-4 rounded-[10px] mb-3">
+      {tickets.map(ticket => (
+        <div key={ticket.ticketId} className="bg-gray1 px-3 py-3 md:px-6 md:py-4 rounded-[10px] mb-3">
           <div className="flex justify-between items-center">
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2 md:gap-4">
@@ -45,13 +68,13 @@ const TicketInfo = () => {
               <div className="flex gap-1 md:gap-2">
                 <TextButton
                   label="-"
-                  onClick={() => handleDecrement(ticket.eventId)}
+                  onClick={() => handleDecrement(ticket.ticketId)}
                   className="flex justify-center items-center bg-white w-6 h-6 md:w-7 md:h-7"
                 />
-                <span>{quantity[ticket.eventId]}</span>
+                <span>{quantity[ticket.ticketId]}</span>
                 <TextButton
                   label="+"
-                  onClick={() => handleIncrement(ticket.eventId)}
+                  onClick={() => handleIncrement(ticket.ticketId)}
                   className="flex justify-center items-center bg-white w-6 h-6 md:w-7 md:h-7"
                 />
               </div>


### PR DESCRIPTION
## 이벤트 상세 조회 페이지 API 연동
<img width="384" alt="스크린샷 2025-04-02 오후 7 54 29" src="https://github.com/user-attachments/assets/ca0008cd-ebaa-4db8-932f-931288e84934" />

## 티켓 조회 API 연동
<img width="389" alt="스크린샷 2025-04-02 오후 7 54 39" src="https://github.com/user-attachments/assets/1d9d0020-e86a-423f-b43b-dc874ec271c4" />

## 카카오맵 추가
<img width="386" alt="스크린샷 2025-04-02 오후 8 01 48" src="https://github.com/user-attachments/assets/88693850-214b-456d-a6e4-5848a6bf6115" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 이벤트 상세 페이지가 비동기로 로드되어 세부 정보와 지도 표시 기능이 추가되었습니다.
	- 티켓 정보가 동적으로 로드되며, 수량 조절 및 최신 이벤트 정보를 명확하게 확인할 수 있게 되었습니다.
- **스타일**
	- QR 코드 모달의 아이콘 이미지에 적절한 좌측 여백이 추가되어 시각적 일관성이 향상되었습니다.
- **리팩터**
	- 주최자 정보 제공 방식이 개선되어 필요한 정보가 직접 전달되고, 해시태그 표시 로직이 수정되어 안정적인 UI 렌더링을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->