### PR TITLE
feat: 소셜 로그인 기능 및 회원가입 구현

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 jobs:
   storybook:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       status: ${{ job.status }}
     steps:

--- a/src/app/provider/authStore.ts
+++ b/src/app/provider/authStore.ts
@@ -24,7 +24,7 @@ export const useAuthStore = create<AuthStore>()(
       closeModal: () => set({ isModalOpen: false }),
 
       login: () => set({ isLoggedIn: true }),
-      logout: () => set({ isLoggedIn: false }),
+      logout: () => set({ isLoggedIn: false, name: null }),
 
       name: null,
       setName: (name) => set({ name }),

--- a/src/app/provider/authStore.ts
+++ b/src/app/provider/authStore.ts
@@ -2,10 +2,12 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 interface AuthStore {
-  accessToken: string | null;
-  refreshToken: string | null;
-  setAccessToken: (token: string | null) => void;
-  setRefreshToken: (token: string | null) => void;
+  isLoggedIn: boolean;
+  login: () => void;
+  logout: () => void;
+
+  name: string | null;
+  setName: (name: string) => void;
 
   isModalOpen: boolean;
   openModal: () => void;
@@ -15,13 +17,17 @@ interface AuthStore {
 export const useAuthStore = create<AuthStore>()(
   persist(
     (set) => ({
-      accessToken: null,
-      refreshToken: null,
-      setAccessToken: (token) => set({ accessToken: token }),
-      setRefreshToken: (token) => set({ refreshToken: token }),
+      isLoggedIn: false,
       isModalOpen: false,
+
       openModal: () => set({ isModalOpen: true }),
       closeModal: () => set({ isModalOpen: false }),
+
+      login: () => set({ isLoggedIn: true }),
+      logout: () => set({ isLoggedIn: false }),
+
+      name: null,
+      setName: (name) => set({ name }),
     }), { name: 'auth-storage' }
   )
 );

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -35,6 +35,7 @@ import ResponseManagementPage from '../../pages/dashboard/ui/ResponsesManagement
 import TicketOptionResponsePage from '../../pages/dashboard/ui/ticket/TicketOptionResponsePage';
 import TicketOptionAttachPage from '../../pages/dashboard/ui/ticket/TicketOptionAttachPage';
 import AuthCallback from '../../pages/join/AuthCallback';
+import LogoutPage from '../../pages/join/LogoutPage';
 
 const mainRoutes = [
   { path: MAIN_ROUTES.main, element: <MainPage />, requiresAuth: false },
@@ -59,6 +60,7 @@ const menuRoutes = [
   { path: MENU_ROUTES.hostEdit, element: <HostEditPage />, requiresAuth: false },
   { path: MENU_ROUTES.myPage, element: <MyPage />, requiresAuth: false },
   { path: MENU_ROUTES.hostInfo, element: <HostInfoPage />, requiresAuth: false },
+  { path: MENU_ROUTES.logout, element: <LogoutPage />, requiresAuth: false },
 ];
 
 const dashboardRoutes = [

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -34,6 +34,7 @@ import TicketOptionCreatePage from '../../pages/dashboard/ui/ticket/TicketOption
 import ResponseManagementPage from '../../pages/dashboard/ui/ResponsesManagementPage';
 import TicketOptionResponsePage from '../../pages/dashboard/ui/ticket/TicketOptionResponsePage';
 import TicketOptionAttachPage from '../../pages/dashboard/ui/ticket/TicketOptionAttachPage';
+import AuthCallback from '../../pages/join/AuthCallback';
 
 const mainRoutes = [
   { path: MAIN_ROUTES.main, element: <MainPage />, requiresAuth: false },
@@ -48,6 +49,7 @@ const mainRoutes = [
 const joinRoutes = [
   { path: JOIN_ROUTES.agreement, element: <AgreementPage />, requiresAuth: false },
   { path: JOIN_ROUTES.infoInput, element: <InfoInputPage />, requiresAuth: false },
+  { path: JOIN_ROUTES.authCallback, element: <AuthCallback />, requiresAuth: false },
 ];
 
 const menuRoutes = [

--- a/src/app/routes/routes.ts
+++ b/src/app/routes/routes.ts
@@ -28,6 +28,7 @@ export const MENU_ROUTES = {
   hostEdit: `${MAIN_ROUTES.menu}/hostEdit/:id`,
   myPage: `${MAIN_ROUTES.menu}/myPage`,
   hostInfo: `${MAIN_ROUTES.menu}/hostInfo/:id`,
+  logout: `${MAIN_ROUTES.menu}/logout`,
 };
 
 export const DASHBOARD_ROUTES = {

--- a/src/app/routes/routes.ts
+++ b/src/app/routes/routes.ts
@@ -17,6 +17,7 @@ export const JOIN_ROUTES = {
   // 회원가입 관련 페이지
   agreement: '/join/agreement', // 이용약관 페이지
   infoInput: '/join/info-input', // 정보입력 페이지
+  authCallback: '/authCallback' 
 };
 
 export const MENU_ROUTES = {

--- a/src/features/join/api/user.ts
+++ b/src/features/join/api/user.ts
@@ -1,9 +1,9 @@
 import { axiosClient } from "../../../shared/types/api/http-client"
 import { UserInfoRequest, UserInfoResponse } from "../model/userInformation";
 
-export const readUser = async(): Promise<UserInfoResponse> => {
-    const response = await axiosClient.get<UserInfoResponse>('/users');
-    return response.data;
+export const readUser = async (): Promise<UserInfoResponse> => {
+    const response = await axiosClient.get<{ result: UserInfoResponse }>('/users');
+    return response.data.result;  
 }
 
 export const updateUser = async(data: UserInfoRequest): Promise<UserInfoResponse> => {

--- a/src/features/join/api/user.ts
+++ b/src/features/join/api/user.ts
@@ -1,0 +1,12 @@
+import { axiosClient } from "../../../shared/types/api/http-client"
+import { UserInfoRequest, UserInfoResponse } from "../model/userInformation";
+
+export const readUser = async(): Promise<UserInfoResponse> => {
+    const response = await axiosClient.get<UserInfoResponse>('/users');
+    return response.data;
+}
+
+export const updateUser = async(data: UserInfoRequest): Promise<UserInfoResponse> => {
+    const response = await axiosClient.put<UserInfoResponse>('/users', data);
+    return response.data;
+}

--- a/src/features/join/hooks/useUserHook.ts
+++ b/src/features/join/hooks/useUserHook.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { readUser, updateUser } from '../api/user';
+import { UserInfoRequest, UserInfoResponse } from '../model/userInformation';
+
+export const useUserInfo = () => {
+    return useQuery<UserInfoResponse>({
+        queryKey: ['userInfo'],
+        queryFn: readUser,
+    });
+};
+
+export const useUserUpdate = () => {
+    return useMutation<UserInfoResponse, Error, UserInfoRequest>({
+        mutationFn: updateUser,
+    });
+}

--- a/src/features/join/model/userInformation.ts
+++ b/src/features/join/model/userInformation.ts
@@ -1,0 +1,13 @@
+export interface UserInfoResponse {
+    id: number;
+    name: string;
+    phoneNumber: string;
+    email: string;
+}
+
+export interface UserInfoRequest {
+    id: number;
+    name: string;
+    phoneNumber: string;
+    email: string;
+}

--- a/src/pages/event/ui/EventDetailsPage.tsx
+++ b/src/pages/event/ui/EventDetailsPage.tsx
@@ -47,7 +47,7 @@ const EventDetailsPage = () => {
   const [clickedLike, setClickedLike] = useState(false);
 
   const [event, setEvent] = useState<ReadEvent | null>(null);
-  const eventId = 1; //수정 필요
+  const eventId = 21; //수정 필요
 
   const handleShareClick = (title: string) => {
     setTitle(title);

--- a/src/pages/home/ui/MainPage.tsx
+++ b/src/pages/home/ui/MainPage.tsx
@@ -26,13 +26,12 @@ const MainPage = () => {
     { img: secondPage, link: 'https://example.com/page2' },
     { img: thirdPage, link: 'https://example.com/page3' },
   ];
-
   const [latestStartIndex, setLatestStartIndex] = useState<number>(0);
   const [trendingStartIndex, setTrendingStartIndex] = useState<number>(0);
   const [closingStartIndex, setClosingStartIndex] = useState<number>(0);
   const maxCardsToShow = 2;
   const navigate = useNavigate();
-  const { isModalOpen, openModal, closeModal} = useAuthStore();
+  const { isModalOpen, openModal, closeModal, isLoggedIn, name} = useAuthStore();
 
   type SetStartIndex = Dispatch<SetStateAction<number>>;
 
@@ -43,7 +42,7 @@ const MainPage = () => {
   const handlePrev = (setStartIndex: SetStartIndex, currentIndex: number, eventsLength: number): void => {
     setStartIndex((currentIndex - 1 + eventsLength) % eventsLength);
   };
-
+  
   return (
     <div className="flex flex-col items-center pb-24">
       <Header
@@ -58,7 +57,7 @@ const MainPage = () => {
         leftButtonClassName="sm:text-lg md:text-xl lg:text-2xl font-extrabold font-nexon"
         leftButtonClick={() => { }}
         leftButtonLabel="같이가요"
-        rightContent={<SecondaryButton size="large" color="black" label="로그인" onClick={openModal} />}
+        rightContent={<SecondaryButton size="large" color="black" label={isLoggedIn ? `${name}님`  : '로그인'} onClick={openModal} />}
       />
       <AnimatePresence>{isModalOpen && <LoginModal onClose={closeModal} />}</AnimatePresence>
 

--- a/src/pages/home/ui/MainPage.tsx
+++ b/src/pages/home/ui/MainPage.tsx
@@ -57,7 +57,7 @@ const MainPage = () => {
         leftButtonClassName="sm:text-lg md:text-xl lg:text-2xl font-extrabold font-nexon"
         leftButtonClick={() => { }}
         leftButtonLabel="같이가요"
-        rightContent={<SecondaryButton size="large" color="black" label={isLoggedIn ? `${name}님`  : '로그인'} onClick={openModal} />}
+        rightContent={<SecondaryButton size="large" color="black" label={isLoggedIn ? `${name}님`  : '로그인'} onClick={isLoggedIn ? closeModal : openModal} />}
       />
       <AnimatePresence>{isModalOpen && <LoginModal onClose={closeModal} />}</AnimatePresence>
 

--- a/src/pages/join/AuthCallback.tsx
+++ b/src/pages/join/AuthCallback.tsx
@@ -15,11 +15,11 @@ const AuthCallback = () => {
             try {
                 login();
                 if (status === 'new') {
-                    //navigate('/join/agreement');
+                    navigate('/join/agreement');
                 } else {
-                    setName(data?.name || "바보");
+                    setName(data?.name || "사용자");
                     console.log(isModalOpen);
-                    //navigate('/');
+                    navigate('/');
                 }
             } catch (error) {
                 console.error('인증 처리 실패', error);

--- a/src/pages/join/AuthCallback.tsx
+++ b/src/pages/join/AuthCallback.tsx
@@ -7,20 +7,19 @@ const AuthCallback = () => {
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     const status = searchParams.get('status'); // 'new' or 'existing'
-    const { login, setName, closeModal,isModalOpen } = useAuthStore();
+    const { login, setName, isModalOpen } = useAuthStore();
     const { data } = useUserInfo();
 
     useEffect(() => {
         const handleAuth = async () => {
             try {
                 login();
-                closeModal();
                 if (status === 'new') {
-                    navigate('/join/agreement');
+                    //navigate('/join/agreement');
                 } else {
                     setName(data?.name || "바보");
                     console.log(isModalOpen);
-                    navigate('/');
+                    //navigate('/');
                 }
             } catch (error) {
                 console.error('인증 처리 실패', error);

--- a/src/pages/join/AuthCallback.tsx
+++ b/src/pages/join/AuthCallback.tsx
@@ -13,10 +13,10 @@ const AuthCallback = () => {
     useEffect(() => {
         const handleAuth = async () => {
             try {
-                login();
                 if (status === 'new') {
                     navigate('/join/agreement');
                 } else {
+                    login();
                     setName(data?.name || "사용자");
                     console.log(isModalOpen);
                     navigate('/');

--- a/src/pages/join/AuthCallback.tsx
+++ b/src/pages/join/AuthCallback.tsx
@@ -1,0 +1,38 @@
+import { useNavigate, useSearchParams } from "react-router-dom";
+import useAuthStore from "../../app/provider/authStore";
+import { useEffect } from "react";
+import { useUserInfo } from "../../features/join/hooks/useUserHook";
+
+const AuthCallback = () => {
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const status = searchParams.get('status'); // 'new' or 'existing'
+    const { login, setName, closeModal,isModalOpen } = useAuthStore();
+    const { data } = useUserInfo();
+
+    useEffect(() => {
+        const handleAuth = async () => {
+            try {
+                login();
+                closeModal();
+                if (status === 'new') {
+                    navigate('/join/agreement');
+                } else {
+                    setName(data?.name || "바보");
+                    console.log(isModalOpen);
+                    navigate('/');
+                }
+            } catch (error) {
+                console.error('인증 처리 실패', error);
+                navigate('/');
+            }
+        };
+        handleAuth();
+    }, []);
+
+    return <div className="text-center mt-32 text-lg font-bold">로그인 중입니다...</div>;
+};
+
+export default AuthCallback;
+
+

--- a/src/pages/join/AuthCallback.tsx
+++ b/src/pages/join/AuthCallback.tsx
@@ -27,7 +27,7 @@ const AuthCallback = () => {
             }
         };
         handleAuth();
-    }, []);
+    }, [data, navigate, login, status, setName, isModalOpen]);
 
     return <div className="text-center mt-32 text-lg font-bold">로그인 중입니다...</div>;
 };

--- a/src/pages/join/InfoInputPage.tsx
+++ b/src/pages/join/InfoInputPage.tsx
@@ -5,9 +5,11 @@ import UnderlineTextField from '../../../design-system/ui/textFields/UnderlineTe
 import { useNavigate } from 'react-router-dom';
 import { FormData, zodValidation } from '../../shared/lib/formValidation';
 import { useUserInfo, useUserUpdate } from '../../features/join/hooks/useUserHook';
+import useAuthStore from '../../app/provider/authStore';
 
 const InfoInputPage = () => {
   const { data, isLoading } = useUserInfo();
+  const { login, setName} = useAuthStore();
   const { mutate: updateUser } = useUserUpdate();
   const {
     register,
@@ -31,6 +33,8 @@ const InfoInputPage = () => {
     };
     updateUser(updatedData, {
       onSuccess: () => {
+        login();
+        setName(data?.name || "사용자");
         alert('정보가 성공적으로 업데이트되었습니다.');
         navigate('/');
       },

--- a/src/pages/join/InfoInputPage.tsx
+++ b/src/pages/join/InfoInputPage.tsx
@@ -12,7 +12,6 @@ const InfoInputPage = () => {
   const {
     register,
     handleSubmit,
-    watch,
     formState: { errors, isValid },
   } = useForm<FormData>({
     mode: 'onChange',
@@ -22,11 +21,6 @@ const InfoInputPage = () => {
 
   const nameValue = data?.name;
   const emailValue = data?.email;
-  const phoneInput = watch('phone');
-  
-
-  // 버튼 활성화 조건
-  const isButtonEnabled = nameValue && phoneInput && emailValue && isValid;
 
   const onSubmit: SubmitHandler<FormData> = formData => {
     const updatedData = {
@@ -73,7 +67,7 @@ const InfoInputPage = () => {
         {/* 연락처 필드 */}
         <UnderlineTextField
           label="연락처"
-          placeholder={`"-" 없이 번호만 입력해주세요`}
+          placeholder={"전화번호를 010-1234-5678 형식으로 입력해주세요."}
           type="tel"
           errorMessage={errors.phone?.message}
           className="text-xl"
@@ -96,7 +90,7 @@ const InfoInputPage = () => {
         <Button
           label="시작하기"
           onClick={handleSubmit(onSubmit)}
-          disabled={!isButtonEnabled}
+          disabled={!isValid}
           className="w-full h-12 rounded-full"
         />
       </div>

--- a/src/pages/join/InfoInputPage.tsx
+++ b/src/pages/join/InfoInputPage.tsx
@@ -6,23 +6,27 @@ import { useNavigate } from 'react-router-dom';
 import { FormData, zodValidation } from '../../shared/lib/formValidation';
 import { useUserInfo, useUserUpdate } from '../../features/join/hooks/useUserHook';
 import useAuthStore from '../../app/provider/authStore';
+import { useEffect } from 'react';
 
 const InfoInputPage = () => {
   const { data, isLoading } = useUserInfo();
-  const { login, setName} = useAuthStore();
+  const { login, setName } = useAuthStore();
   const { mutate: updateUser } = useUserUpdate();
   const {
     register,
     handleSubmit,
     formState: { errors, isValid },
+    reset,
   } = useForm<FormData>({
     mode: 'onChange',
+    defaultValues: {
+      name: '',
+      email: '',
+      phone: '',
+    },
     ...zodValidation,
   });
   const navigate = useNavigate();
-
-  const nameValue = data?.name;
-  const emailValue = data?.email;
 
   const onSubmit: SubmitHandler<FormData> = formData => {
     const updatedData = {
@@ -44,7 +48,15 @@ const InfoInputPage = () => {
       },
     });
   };
-
+  useEffect(() => {
+    if (data) {
+      reset({
+        name: data.name || '',
+        email: data.email || '',
+        phone: '',
+      });
+    }
+  }, [data, reset]);
   if (isLoading) {
     return <div>로딩 중...</div>;
   }
@@ -62,7 +74,6 @@ const InfoInputPage = () => {
         <UnderlineTextField
           label="이름"
           placeholder="이름"
-          value={nameValue}
           errorMessage={errors.name?.message}
           className="text-xl"
           {...register('name')}
@@ -82,7 +93,6 @@ const InfoInputPage = () => {
         <UnderlineTextField
           label="이메일"
           placeholder="이메일"
-          value={emailValue}
           type="email"
           errorMessage={errors.email?.message}
           className="text-xl"

--- a/src/pages/join/InfoInputPage.tsx
+++ b/src/pages/join/InfoInputPage.tsx
@@ -12,6 +12,7 @@ const InfoInputPage = () => {
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors, isValid },
   } = useForm<FormData>({
     mode: 'onChange',
@@ -22,9 +23,11 @@ const InfoInputPage = () => {
   const nameValue = data?.name;
   const phoneValue = data?.phoneNumber;
   const emailValue = data?.email;
+  const phoneInput = watch('phone');
+  
 
   // 버튼 활성화 조건
-  const isButtonEnabled = nameValue && phoneValue && emailValue && isValid;
+  const isButtonEnabled = nameValue && phoneInput && emailValue && isValid;
 
   const onSubmit: SubmitHandler<FormData> = formData => {
     const updatedData = {

--- a/src/pages/join/InfoInputPage.tsx
+++ b/src/pages/join/InfoInputPage.tsx
@@ -4,16 +4,15 @@ import Button from '../../../design-system/ui/Button';
 import UnderlineTextField from '../../../design-system/ui/textFields/UnderlineTextField';
 import { useNavigate } from 'react-router-dom';
 import { FormData, zodValidation } from '../../shared/lib/formValidation';
+import { useUserInfo, useUserUpdate } from '../../features/join/hooks/useUserHook';
 
-const existingNames = ['김원영']; // 중복 이름 예시
-const existingPhones = ['01012345678']; // 중복 연락처 예시
-const existingEmails = ['example@example.com']; // 중복 이메일 예시
+const { data } = useUserInfo();
+const { mutate: updateUser} = useUserUpdate();
 
 const InfoInputPage = () => {
   const {
     register,
     handleSubmit,
-    watch,
     formState: { errors, isValid },
   } = useForm<FormData>({
     mode: 'onChange',
@@ -21,15 +20,30 @@ const InfoInputPage = () => {
   });
   const navigate = useNavigate();
 
-  const nameValue = watch('name');
-  const phoneValue = watch('phone');
-  const emailValue = watch('email');
+  const nameValue = data?.name;
+  const phoneValue = data?.phoneNumber;
+  const emailValue = data?.email;
 
   // 버튼 활성화 조건
   const isButtonEnabled = nameValue && phoneValue && emailValue && isValid;
 
-  const onSubmit: SubmitHandler<FormData> = data => {
-    console.log('제출 데이터:', data);
+  const onSubmit: SubmitHandler<FormData> = formData => {
+    const updatedData = {
+      id: data?.id || 0,        
+      name: data?.name || "",    
+      email: data?.email || "",  
+      phoneNumber: formData.phone,  
+    };
+    updateUser(updatedData, {
+      onSuccess: () => {
+        alert('정보가 성공적으로 업데이트되었습니다.');
+        navigate('/'); 
+      },
+      onError: (err) => {
+        alert('정보 업데이트에 실패했습니다. 다시 시도해주세요.');
+        console.error(err);
+      },
+    });
     alert('정보 입력 완료!');
   };
 
@@ -54,13 +68,10 @@ const InfoInputPage = () => {
         <UnderlineTextField
           label="이름"
           placeholder="이름"
+          value={nameValue}
           errorMessage={errors.name?.message}
           className="text-xl"
-          {...register('name', {
-            validate: {
-              notDuplicate: value => !existingNames.includes(value) || '이미 존재하는 이름입니다.',
-            },
-          })}
+          {...register('name')}
         />
 
         {/* 연락처 필드 */}
@@ -70,25 +81,18 @@ const InfoInputPage = () => {
           type="tel"
           errorMessage={errors.phone?.message}
           className="text-xl"
-          {...register('phone', {
-            validate: {
-              notDuplicate: value => !existingPhones.includes(value) || '이미 존재하는 연락처입니다.',
-            },
-          })}
+          {...register('phone')}
         />
 
         {/* 이메일 필드 */}
         <UnderlineTextField
           label="이메일"
           placeholder="이메일"
+          value={emailValue}
           type="email"
           errorMessage={errors.email?.message}
           className="text-xl"
-          {...register('email', {
-            validate: {
-              notDuplicate: value => !existingEmails.includes(value) || '이미 존재하는 이메일입니다.',
-            },
-          })}
+          {...register('email')}
         />
       </form>
       <div className="flex flex-grow" />

--- a/src/pages/join/InfoInputPage.tsx
+++ b/src/pages/join/InfoInputPage.tsx
@@ -6,10 +6,9 @@ import { useNavigate } from 'react-router-dom';
 import { FormData, zodValidation } from '../../shared/lib/formValidation';
 import { useUserInfo, useUserUpdate } from '../../features/join/hooks/useUserHook';
 
-const { data } = useUserInfo();
-const { mutate: updateUser} = useUserUpdate();
-
 const InfoInputPage = () => {
+  const { data, isLoading } = useUserInfo();
+  const { mutate: updateUser } = useUserUpdate();
   const {
     register,
     handleSubmit,
@@ -29,15 +28,15 @@ const InfoInputPage = () => {
 
   const onSubmit: SubmitHandler<FormData> = formData => {
     const updatedData = {
-      id: data?.id || 0,        
-      name: data?.name || "",    
-      email: data?.email || "",  
-      phoneNumber: formData.phone,  
+      id: data?.id || 0,
+      name: data?.name || "",
+      email: data?.email || "",
+      phoneNumber: formData.phone,
     };
     updateUser(updatedData, {
       onSuccess: () => {
         alert('정보가 성공적으로 업데이트되었습니다.');
-        navigate('/'); 
+        navigate('/');
       },
       onError: (err) => {
         alert('정보 업데이트에 실패했습니다. 다시 시도해주세요.');
@@ -53,7 +52,9 @@ const InfoInputPage = () => {
   console.log('email:', emailValue, errors.email?.message);
   console.log('isValid:', isValid);
   console.log('isButtonEnabled:', isButtonEnabled);
-
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
   return (
     <div className="relative flex flex-col w-full h-screen border ">
       <Header

--- a/src/pages/join/InfoInputPage.tsx
+++ b/src/pages/join/InfoInputPage.tsx
@@ -21,7 +21,6 @@ const InfoInputPage = () => {
   const navigate = useNavigate();
 
   const nameValue = data?.name;
-  const phoneValue = data?.phoneNumber;
   const emailValue = data?.email;
   const phoneInput = watch('phone');
   
@@ -46,15 +45,8 @@ const InfoInputPage = () => {
         console.error(err);
       },
     });
-    alert('정보 입력 완료!');
   };
 
-  // 디버깅 추가
-  console.log('name:', nameValue, errors.name?.message);
-  console.log('phone:', phoneValue, errors.phone?.message);
-  console.log('email:', emailValue, errors.email?.message);
-  console.log('isValid:', isValid);
-  console.log('isButtonEnabled:', isButtonEnabled);
   if (isLoading) {
     return <div>로딩 중...</div>;
   }

--- a/src/pages/join/LogoutPage.tsx
+++ b/src/pages/join/LogoutPage.tsx
@@ -1,21 +1,24 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { axiosClient } from '../../shared/types/api/http-client';
+import useAuthStore from '../../app/provider/authStore';
 
 const LogoutPage = () => {
   const navigate = useNavigate();
+  const { logout } = useAuthStore();
 
   useEffect(() => {
-    const logout = async () => {
+    const handleLogout = async () => {
       try {
         await axiosClient.post('/oauth/logout');
+        logout();
         navigate('/');
       } catch (error) {
         console.error('로그아웃 실패:', error);
         alert('로그아웃에 실패했습니다. 다시 시도해주세요.');
       }
     };
-    logout();
+    handleLogout();
   }, [navigate]);
 
   return <div>로그아웃 중...</div>;

--- a/src/pages/join/LogoutPage.tsx
+++ b/src/pages/join/LogoutPage.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { axiosClient } from '../../shared/types/api/http-client';
+
+const LogoutPage = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const logout = async () => {
+      try {
+        await axiosClient.post('/oauth/logout');
+        navigate('/');
+      } catch (error) {
+        console.error('로그아웃 실패:', error);
+        alert('로그아웃에 실패했습니다. 다시 시도해주세요.');
+      }
+    };
+    logout();
+  }, [navigate]);
+
+  return <div>로그아웃 중...</div>;
+};
+
+export default LogoutPage;

--- a/src/pages/menu/ui/MyTicketPage.tsx
+++ b/src/pages/menu/ui/MyTicketPage.tsx
@@ -8,9 +8,6 @@ import { readTicket } from '../../../features/ticket/api/order';
 import completedImg from '../../../../public/assets/menu/Completed.svg';
 import pendingImg from '../../../../public/assets/menu/Pending.svg';
 import ticketImg from '../../../../public/assets/menu/Ticket.svg';
-import useAuthStore from '../../../app/provider/authStore';
-import Cookies from 'js-cookie';
-
 type Ticket = {
   id: number;
   event: {
@@ -35,22 +32,7 @@ const MyTicketPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [myTickets, setMyTickets] = useState<Ticket[]>([]);
   const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
-  const { setAccessToken, setRefreshToken } = useAuthStore();
-  useEffect(() => {
-    const accessToken = Cookies.get('access-token');
-    const refreshToken = Cookies.get('refresh-token');
-  
-    console.log("access-token:", accessToken);
-    console.log("refresh-token:", refreshToken);
-  
-    if (accessToken) {
-      setAccessToken(accessToken);
-    }
-    if (refreshToken) {
-      setRefreshToken(refreshToken);
-    }
-  }, []);
-  
+
   useEffect(() => {
     const fetchMyTickets = async () => {
       try {

--- a/src/shared/lib/formValidation.ts
+++ b/src/shared/lib/formValidation.ts
@@ -7,7 +7,10 @@ export const formSchema = z.object({
     .string()
     .email('올바른 이메일 형식이어야 합니다.')
     .regex(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/, '올바른 이메일 형식이어야 합니다.'),
-  phone: z.string().regex(/^[0-9]{10,11}$/, '연락처는 10~11자리 숫자여야 합니다.'),
+  phone: z
+    .string()
+    .regex(/^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$/, '연락처는 -을 포함한 형식이어야 합니다.')
+    .min(1, '전화번호를 입력해주세요.'),
 });
 export const organizerFormSchema = formSchema.pick({ email: true, phone: true });
 export const eventTitleSchema = z.object({

--- a/src/shared/types/api/http-client.ts
+++ b/src/shared/types/api/http-client.ts
@@ -4,7 +4,7 @@ import Cookies from 'js-cookie';
 import useAuthStore from '../../../app/provider/authStore';
 
 export const axiosClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: `${import.meta.env.VITE_API_BASE_URL}/api/v1`,
   timeout: 3000,
   withCredentials: true,
   headers: {

--- a/src/shared/types/api/http-client.ts
+++ b/src/shared/types/api/http-client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosResponse } from 'axios';
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { ApiErrorResponse } from './apiResponse';
 import Cookies from 'js-cookie';
 import useAuthStore from '../../../app/provider/authStore';
@@ -36,7 +36,7 @@ axiosClient.interceptors.response.use(
       message: error.response?.data?.message || error.message,
     };
 
-    const originalRequest = error.config as any;
+    const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
 
     // 401(토큰 만료)일 경우 로그아웃 처리 or 토큰 갱신 가능
     if (errorInfo.status === 401) {

--- a/src/shared/types/api/http-client.ts
+++ b/src/shared/types/api/http-client.ts
@@ -4,24 +4,16 @@ import Cookies from 'js-cookie';
 import useAuthStore from '../../../app/provider/authStore';
 
 export const axiosClient = axios.create({
-  baseURL: 'http://api.gotogether.io.kr:8080/api/v1',
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 3000,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
-    //Authorization: `Bearer `,
   },
 });
 
 axiosClient.interceptors.request.use(
   config => {
-    //const token = Cookies.get('access_token');
-    //zustand 사용함으로써 코드변경 할 듯 현재는 임시 입니다.
-    // const token = useAuthStore.getState().accessToken;
-    // if (token) {
-    //   config.headers.Authorization = `Bearer ${token}`;
-    // }
-
     return config;
   },
   (error: AxiosError) => {

--- a/src/widgets/main/ui/LoginModal.tsx
+++ b/src/widgets/main/ui/LoginModal.tsx
@@ -10,9 +10,11 @@ interface LoginModalProps {
 
 const LoginModal = ({ onClose }: LoginModalProps) => {
   const kakaoLogin = () => {
+    onClose();
     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/kakao`;
   };
   const gooleLogin = () => {
+    onClose();
     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/google`;
   };
   return (

--- a/src/widgets/main/ui/LoginModal.tsx
+++ b/src/widgets/main/ui/LoginModal.tsx
@@ -10,11 +10,9 @@ interface LoginModalProps {
 
 const LoginModal = ({ onClose }: LoginModalProps) => {
   const kakaoLogin = () => {
-    onClose();
     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/kakao`;
   };
   const gooleLogin = () => {
-    onClose();
     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/google`;
   };
   return (


### PR DESCRIPTION
## 소셜 로그인 구현 - 카카오 & 구글
<img width="383" alt="스크린샷 2025-04-27 오후 5 34 52" src="https://github.com/user-attachments/assets/8f1083df-4962-4ef8-af5a-43606493b6a2" />

## 카카오 로그인
<img width="514" alt="스크린샷 2025-04-27 오후 5 35 16" src="https://github.com/user-attachments/assets/b59b1e4c-24c8-4cf9-b82d-87a10937770d" />

## 구글 로그인 
<img width="519" alt="스크린샷 2025-04-27 오후 5 35 59" src="https://github.com/user-attachments/assets/9bb901f9-fe2c-49b9-b4f1-40302eda8230" />

## 신규 로그인 시 이용약관 동의 페이지로 이동
<img width="385" alt="스크린샷 2025-04-27 오후 5 36 14" src="https://github.com/user-attachments/assets/a1e9f0ab-7314-4a1d-8d45-267da10e4cbc" />

## 이름, 이메일은 자동으로 불러오고 전화번호만 입력받음.
<img width="381" alt="스크린샷 2025-04-27 오후 6 04 13" src="https://github.com/user-attachments/assets/8541b737-3e95-4c3b-ac00-f73e7f132b12" />

<img width="461" alt="스크린샷 2025-04-27 오후 6 04 31" src="https://github.com/user-attachments/assets/1f6fe750-1cc0-4bbb-91a3-ab7515be2ba8" />

## 전화번호 입력 형식 변경
<img width="385" alt="스크린샷 2025-04-29 오후 2 14 54" src="https://github.com/user-attachments/assets/3e1665c6-0fc5-4eae-90ea-0bcb9c8cfb73" />
<img width="381" alt="스크린샷 2025-04-29 오후 2 15 09" src="https://github.com/user-attachments/assets/cd879488-c505-4823-a7c4-2652f71a126e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자 정보 조회 및 수정 API와 관련 커스텀 훅 추가
  - 로그인 콜백(AuthCallback) 및 로그아웃(LogoutPage) 페이지 추가
  - 사용자 이름 표시 및 로그인 상태 반영 UI 개선

- **버그 수정**
  - 이벤트 상세 페이지에서 이벤트 ID 변경(1 → 21)

- **리팩터**
  - 인증 상태 관리 방식 단순화(토큰 → 로그인 여부, 이름 등)

- **스타일/UX**
  - 로그인 버튼이 로그인 시 사용자 이름으로 표시되도록 개선
  - 전화번호 입력 폼 유효성 검사 규칙을 하이픈 포함 형식으로 변경

- **기타**
  - Storybook 워크플로우의 우분투 버전 업데이트(20.04 → 22.04)
  - API 서버 주소를 환경 변수 기반으로 변경
  - 인증 토큰 자동 갱신 및 만료 시 로그아웃 모달 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->