### PR TITLE
feat: 마이페이지 api 연동

### DIFF
--- a/src/pages/menu/ui/MyPage.tsx
+++ b/src/pages/menu/ui/MyPage.tsx
@@ -10,7 +10,7 @@ import { useUserInfo,useUserUpdate } from '../../../features/join/hooks/useUserH
 import useAuthStore from '../../../app/provider/authStore';
 
 const MyPage = () => {
-  const {data} = useUserInfo();
+  const {data, isLoading, error} = useUserInfo();
   const { mutate: updateUser } = useUserUpdate();
   const { setName } = useAuthStore();
 
@@ -41,7 +41,7 @@ const MyPage = () => {
     };
     updateUser(updatedData, {
       onSuccess: () => {
-        setName(data?.name || "사용자");
+        setName(name);
         alert('정보가 성공적으로 업데이트되었습니다.');
       },
       onError: (err) => {
@@ -62,6 +62,12 @@ const MyPage = () => {
     setIsChanged(changeMessage); // 변경 상태 업데이트
 
   };
+  if (isLoading) {
+    return <div>로딩 중...</div>; 
+  }
+  if (error) {
+    return <div>정보를 불러오는데 실패했습니다. 다시 시도해주세요.</div>;
+  }
   return (
     <div>
       <Header leftButtonLabel="마이페이지" leftButtonClassName="font-bold text-2xl" />


### PR DESCRIPTION
## 유저 정보 불러오기
<img width="361" alt="스크린샷 2025-04-29 오후 4 41 07" src="https://github.com/user-attachments/assets/a5b06c1f-1298-4397-bded-e7e7f0d096be" />

## 정보 입력받아 수정하기
<img width="366" alt="스크린샷 2025-04-29 오후 4 41 40" src="https://github.com/user-attachments/assets/fc82f0f1-eebb-4e8f-b2d0-55fe363575e2" />
<img width="448" alt="스크린샷 2025-04-29 오후 4 42 07" src="https://github.com/user-attachments/assets/781a64e3-dd2b-47cb-96c9-217dae1610fd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 사용자 정보가 하드코딩 방식에서 동적으로 불러오는 방식으로 개선되었습니다.
  - 폼의 기본값과 입력란이 실제 사용자 데이터로 자동 초기화되고, 변경 시 자동 반영됩니다.
  - 저장 시 성공 및 실패 알림이 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->