### PR TITLE
feat: 호스트 정보 수정 API 연동

### DIFF
--- a/src/entities/host/api/hostChannelInfo.ts
+++ b/src/entities/host/api/hostChannelInfo.ts
@@ -1,0 +1,8 @@
+import { axiosClient } from '../../../shared/types/api/http-client';
+import { HostChannelInfoRequest, HostChannelInfoResponse } from '../model/hostChannelInfo';
+
+const hostChannelInfo = async (dto: HostChannelInfoRequest) => {
+  const response = await axiosClient.get<HostChannelInfoResponse>(`/host-channels/${dto.hostChannelId}/info`);
+  return response.data;
+};
+export default hostChannelInfo;

--- a/src/entities/host/hook/useHostChannelInfoHook.tsx
+++ b/src/entities/host/hook/useHostChannelInfoHook.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import hostChannelInfo from '../api/hostChannelInfo';
+
+const useHostChannelInfo = (hostChannelId: number) => {
+  const { data } = useQuery({
+    queryKey: ['hostInfo', hostChannelId],
+    queryFn: () => hostChannelInfo({ hostChannelId }),
+    enabled: !!hostChannelId,
+  });
+  return { data };
+};
+export default useHostChannelInfo;

--- a/src/entities/host/hook/useHostDetailHook.ts
+++ b/src/entities/host/hook/useHostDetailHook.ts
@@ -5,6 +5,7 @@ const useHostDetail = (hostChannelId: number) => {
   const { data } = useQuery({
     queryKey: ['hostDetail', hostChannelId],
     queryFn: () => hostDetail({ hostChannelId }),
+    enabled: !!hostChannelId,
   });
 
   return { data };

--- a/src/entities/host/model/hostChannelInfo.ts
+++ b/src/entities/host/model/hostChannelInfo.ts
@@ -1,0 +1,14 @@
+export interface HostChannelInfoRequest {
+  hostChannelId: number;
+}
+
+export interface HostChannelInfoResponse {
+  result: {
+    id: number;
+    profileImageUrl: string;
+    hostChannelName: string;
+    channelDescription: string;
+    email: string;
+    hostChannelMembers: { id: number; memberName: string }[];
+  };
+}

--- a/src/features/host/api/host.ts
+++ b/src/features/host/api/host.ts
@@ -1,0 +1,8 @@
+import { axiosClient } from '../../../shared/types/api/http-client';
+import { UpdateHostChannelInfoRequest } from '../model/host';
+
+const updateHostInfo = async (hostChannelId: number, dto: UpdateHostChannelInfoRequest) => {
+  const response = await axiosClient.put(`/host-channels/${hostChannelId}`, dto);
+  return response.data;
+};
+export default updateHostInfo;

--- a/src/features/host/hook/useHostHook.ts
+++ b/src/features/host/hook/useHostHook.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import updateHostInfo from '../api/host';
+import { UpdateHostChannelInfoRequest } from '../model/host';
+import { useParams } from 'react-router-dom';
+
+export const useUpdateHostChannelInfo = () => {
+  const { id } = useParams();
+  const hostChannelId = Number(id);
+
+  const mutation = useMutation({
+    mutationFn: (dto: UpdateHostChannelInfoRequest) => updateHostInfo(hostChannelId, dto),
+  });
+  return mutation;
+};

--- a/src/features/host/hook/useHostHook.ts
+++ b/src/features/host/hook/useHostHook.ts
@@ -1,12 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import updateHostInfo from '../api/host';
 import { UpdateHostChannelInfoRequest } from '../model/host';
-import { useParams } from 'react-router-dom';
 
-export const useUpdateHostChannelInfo = () => {
-  const { id } = useParams();
-  const hostChannelId = Number(id);
-
+export const useUpdateHostChannelInfo = (hostChannelId: number) => {
   const mutation = useMutation({
     mutationFn: (dto: UpdateHostChannelInfoRequest) => updateHostInfo(hostChannelId, dto),
   });

--- a/src/features/host/model/host.ts
+++ b/src/features/host/model/host.ts
@@ -1,0 +1,6 @@
+export interface UpdateHostChannelInfoRequest {
+  profileImageUrl: string;
+  hostChannelName: string;
+  hostEmail: string;
+  channelDescription: string;
+}

--- a/src/pages/menu/ui/myHost/HostDetailPage.tsx
+++ b/src/pages/menu/ui/myHost/HostDetailPage.tsx
@@ -20,7 +20,7 @@ const HostDetailPage = () => {
       }
     >
       <div className="grid grid-cols-2 gap-4 mx-5 mt-3 md:grid-cols-2 lg:grid-cols-2 z-50">
-        {data?.result.events.map(event => (
+        {data?.result.events?.map(event => (
           <EventCard
             id={event.id}
             key={event.id}

--- a/src/pages/menu/ui/myHost/HostDetailPage.tsx
+++ b/src/pages/menu/ui/myHost/HostDetailPage.tsx
@@ -1,15 +1,15 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import HostDetailLayout from '../../../../shared/ui/backgrounds/HostDetailLayout';
-import { trendingEvents } from '../../../../shared/types/eventCardType';
 import EventCard from '../../../../shared/ui/EventCard';
+import useHostDetail from '../../../../entities/host/hook/useHostDetailHook';
 
 const HostDetailPage = () => {
   const navigate = useNavigate();
   // URL에서 hostId를 가져오기
   const { id } = useParams<{ id: string }>();
 
-  // hostId에 해당하는 이벤트들만 필터링
-  const filteredEvents = trendingEvents.filter(event => event.id === Number(id));
+  const hostChannelId = Number(id);
+  const { data } = useHostDetail(hostChannelId);
 
   return (
     <HostDetailLayout
@@ -20,16 +20,16 @@ const HostDetailPage = () => {
       }
     >
       <div className="grid grid-cols-2 gap-4 mx-5 mt-3 md:grid-cols-2 lg:grid-cols-2 z-50">
-        {filteredEvents.map((event, index) => (
+        {data?.result.events.map(event => (
           <EventCard
             id={event.id}
-            key={index}
-            img={event.img}
-            eventTitle={event.eventTitle}
-            dDay={event.dDay}
-            host={event.host}
-            eventDate={event.eventDate}
-            location={event.location}
+            key={event.id}
+            img={event.bannerImageUrl}
+            eventTitle={event.title}
+            dDay={event.remainDays}
+            host={event.hostChannelName}
+            eventDate={event.startDate}
+            location={event.onlineType}
             hashtags={event.hashtags}
           />
         ))}

--- a/src/pages/menu/ui/myHost/HostEditPage.tsx
+++ b/src/pages/menu/ui/myHost/HostEditPage.tsx
@@ -7,6 +7,7 @@ import TertiaryButton from '../../../../../design-system/ui/buttons/TertiaryButt
 import { useParams } from 'react-router-dom';
 import MemberEmailInput from '../../../../features/menu/ui/MemberEmailInput';
 import { hostInfo } from '../../../../shared/types/hostInfoType';
+import useHostChannelInfo from '../../../../entities/host/hook/useHostChannelInfoHook';
 
 const HostEditPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -15,7 +16,8 @@ const HostEditPage = () => {
   const [tags, setTags] = useState<string[]>([]);
   const [inputValue, setInputValue] = useState('');
 
-  const user = hostInfo.filter(user => user.id === Number(id));
+  const hostChannelId = Number(id);
+  const { data: hostInfo } = useHostChannelInfo(hostChannelId);
 
   const handeHostInfoClick = () => {
     setSelectedHost(true);
@@ -61,20 +63,20 @@ const HostEditPage = () => {
           <div className="flex flex-col px-8 md:px-12 gap-6">
             <div className="flex flex-col gap-4 py-4">
               <p className="text-xl text-black font-semibold">대표 이메일</p>
-              <p>example@example.com</p>
+              <p>{hostInfo?.result.email}</p>
             </div>
             <div className="flex flex-col gap-4 lg:gap-6">
               <p className="text-xl text-black font-semibold">멤버 목록</p>
               <div className="flex flex-wrap gap-x-5 gap-y-4 lg:gap-x-10 lg:gap-y-6 text-sm md:text-16 lg:text-base">
-                {user.map(user => (
+                {hostInfo?.result.hostChannelMembers.map(user => (
                   <ProfileCircle
                     key={user.id}
                     id={user.id}
                     profile="userProfile"
-                    name={user.nickname}
+                    name={user.memberName.slice(1)}
                     className="w-12 h-12 md:w-13 md:h-13 lg:w-14 lg:h-14 text-sm md:text-16 lg:text-base"
                   >
-                    {user.name}
+                    {user.memberName}
                   </ProfileCircle>
                 ))}
               </div>
@@ -87,14 +89,14 @@ const HostEditPage = () => {
             <DefaultTextField
               label="대표 이메일"
               detail="채널 혹은, 채널에서 주최하는 이벤트에 대해 문의 할 수 있는 메일로 작성해주세요."
-              placeholder="example@example.com"
+              value={hostInfo?.result.email || ''}
               className="h-12"
               labelClassName="sm:text-base md:text-lg"
             />
             <div className="flex flex-col gap-2">
               <MultilineTextField
                 label="채널에 대한 설명"
-                placeholder="채널에 대한 설명을 작성해주세요."
+                value={hostInfo?.result.channelDescription || ''}
                 className="h-24 mb-8"
               />
               <TertiaryButton type="button" label="저장하기" size="large" color="pink" />

--- a/src/pages/menu/ui/myHost/HostEditPage.tsx
+++ b/src/pages/menu/ui/myHost/HostEditPage.tsx
@@ -8,6 +8,7 @@ import { useParams } from 'react-router-dom';
 import MemberEmailInput from '../../../../features/menu/ui/MemberEmailInput';
 import useHostChannelInfo from '../../../../entities/host/hook/useHostChannelInfoHook';
 import { useUpdateHostChannelInfo } from '../../../../features/host/hook/useHostHook';
+import { useQueryClient } from '@tanstack/react-query';
 
 const HostEditPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -20,6 +21,7 @@ const HostEditPage = () => {
   const hostChannelId = Number(id);
   const { data: hostInfo } = useHostChannelInfo(hostChannelId);
   const { mutate } = useUpdateHostChannelInfo();
+  const queryClient = useQueryClient();
 
   const handeHostInfoClick = () => {
     setSelectedHost(true);
@@ -43,6 +45,9 @@ const HostEditPage = () => {
 
     mutate(updatedData, {
       onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['hostInfo', hostChannelId],
+        });
         alert('저장되었습니다.');
       },
       onError: () => {

--- a/src/pages/menu/ui/myHost/HostEditPage.tsx
+++ b/src/pages/menu/ui/myHost/HostEditPage.tsx
@@ -20,7 +20,7 @@ const HostEditPage = () => {
 
   const hostChannelId = Number(id);
   const { data: hostInfo } = useHostChannelInfo(hostChannelId);
-  const { mutate } = useUpdateHostChannelInfo();
+  const { mutate } = useUpdateHostChannelInfo(hostChannelId);
   const queryClient = useQueryClient();
 
   const handeHostInfoClick = () => {

--- a/src/pages/menu/ui/myHost/HostEditPage.tsx
+++ b/src/pages/menu/ui/myHost/HostEditPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import HostDetailLayout from '../../../../shared/ui/backgrounds/HostDetailLayout';
 import ProfileCircle from '../../../../../design-system/ui/Profile';
 import MultilineTextField from '../../../../../design-system/ui/textFields/MultilineTextField';
@@ -6,8 +6,8 @@ import DefaultTextField from '../../../../../design-system/ui/textFields/Default
 import TertiaryButton from '../../../../../design-system/ui/buttons/TertiaryButton';
 import { useParams } from 'react-router-dom';
 import MemberEmailInput from '../../../../features/menu/ui/MemberEmailInput';
-import { hostInfo } from '../../../../shared/types/hostInfoType';
 import useHostChannelInfo from '../../../../entities/host/hook/useHostChannelInfoHook';
+import { useUpdateHostChannelInfo } from '../../../../features/host/hook/useHostHook';
 
 const HostEditPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -15,9 +15,11 @@ const HostEditPage = () => {
   const [selectedInfo, setSelectedInfo] = useState(false);
   const [tags, setTags] = useState<string[]>([]);
   const [inputValue, setInputValue] = useState('');
+  const [channelDescription, setChannelDescription] = useState('');
 
   const hostChannelId = Number(id);
   const { data: hostInfo } = useHostChannelInfo(hostChannelId);
+  const { mutate } = useUpdateHostChannelInfo();
 
   const handeHostInfoClick = () => {
     setSelectedHost(true);
@@ -27,12 +29,40 @@ const HostEditPage = () => {
     setSelectedInfo(true);
     setSelectedHost(false);
   };
+
+  const handleSave = () => {
+    if (!hostInfo?.result.id) return;
+
+    const updatedData = {
+      hostChannelId,
+      profileImageUrl: hostInfo.result.profileImageUrl,
+      hostChannelName: hostInfo.result.hostChannelName,
+      hostEmail: hostInfo.result.email,
+      channelDescription,
+    };
+
+    mutate(updatedData, {
+      onSuccess: () => {
+        alert('저장되었습니다.');
+      },
+      onError: () => {
+        alert('저장에 실패했습니다.');
+      },
+    });
+  };
+
   const handleAddClick = () => {
     if (inputValue.trim() && !tags.includes(inputValue.trim())) {
       setTags([...tags, inputValue.trim()]);
       setInputValue('');
     }
   };
+
+  useEffect(() => {
+    if (hostInfo?.result.channelDescription && channelDescription === '') {
+      setChannelDescription(hostInfo.result.channelDescription);
+    }
+  }, [hostInfo, channelDescription]);
 
   return (
     <HostDetailLayout>
@@ -96,10 +126,11 @@ const HostEditPage = () => {
             <div className="flex flex-col gap-2">
               <MultilineTextField
                 label="채널에 대한 설명"
-                value={hostInfo?.result.channelDescription || ''}
+                value={channelDescription}
+                onChange={e => setChannelDescription(e.target.value)}
                 className="h-24 mb-8"
               />
-              <TertiaryButton type="button" label="저장하기" size="large" color="pink" />
+              <TertiaryButton type="button" label="저장하기" size="large" color="pink" onClick={handleSave} />
             </div>
             <div className="flex flex-col gap-2">
               <div className="flex flex-col">

--- a/src/pages/menu/ui/myHost/HostInfoPage.tsx
+++ b/src/pages/menu/ui/myHost/HostInfoPage.tsx
@@ -20,7 +20,7 @@ const HostInfoPage = () => {
           <div className="flex flex-col gap-4 lg:gap-6">
             <p className="text-xl text-black font-semibold">멤버 목록</p>
             <div className="flex flex-wrap gap-x-5 gap-y-4 lg:gap-x-10 lg:gap-y-6 text-sm md:text-16 lg:text-base">
-              {data?.result.hostChannelMembers.map(user => (
+              {data?.result.hostChannelMembers?.map(user => (
                 <ProfileCircle
                   key={user.id}
                   id={user.id}

--- a/src/pages/menu/ui/myHost/HostInfoPage.tsx
+++ b/src/pages/menu/ui/myHost/HostInfoPage.tsx
@@ -1,12 +1,13 @@
 import HostDetailLayout from '../../../../shared/ui/backgrounds/HostDetailLayout';
 import ProfileCircle from '../../../../../design-system/ui/Profile';
 import { useParams } from 'react-router-dom';
-import { hostInfo } from '../../../../shared/types/hostInfoType';
+import useHostChannelInfo from '../../../../entities/host/hook/useHostChannelInfoHook';
 
 const HostInfoPage = () => {
   const { id } = useParams<{ id: string }>();
 
-  const user = hostInfo.filter(user => user.id === Number(id));
+  const hostChannelId = Number(id);
+  const { data } = useHostChannelInfo(hostChannelId);
 
   return (
     <HostDetailLayout>
@@ -14,20 +15,20 @@ const HostInfoPage = () => {
         <div className="flex flex-col px-8 md:px-12 gap-6">
           <div className="flex flex-col gap-4 py-8">
             <p className="text-xl text-black font-semibold">대표 이메일</p>
-            <p>example@example.com</p>
+            <p>{data?.result.email}</p>
           </div>
           <div className="flex flex-col gap-4 lg:gap-6">
             <p className="text-xl text-black font-semibold">멤버 목록</p>
             <div className="flex flex-wrap gap-x-5 gap-y-4 lg:gap-x-10 lg:gap-y-6 text-sm md:text-16 lg:text-base">
-              {user.map(user => (
+              {data?.result.hostChannelMembers.map(user => (
                 <ProfileCircle
                   key={user.id}
                   id={user.id}
                   profile="userProfile"
-                  name={user.nickname}
+                  name={user.memberName.slice(1)}
                   className="w-12 h-12 md:w-13 md:h-13 lg:w-14 lg:h-14 text-sm md:text-16 lg:text-base"
                 >
-                  {user.name}
+                  {user.memberName}
                 </ProfileCircle>
               ))}
             </div>

--- a/src/shared/ui/backgrounds/HostDetailLayout.tsx
+++ b/src/shared/ui/backgrounds/HostDetailLayout.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import ProfileCircle from '../../../../design-system/ui/Profile';
 import Header from '../../../../design-system/ui/Header';
 import { ButtonHTMLAttributes, ReactElement } from 'react';
-import { hostInfo, hostInfoData } from '../../types/hostInfoType';
+import useHostChannelInfo from '../../../entities/host/hook/useHostChannelInfoHook';
 
 interface HostDetailLayoutProps {
   rightContent?: ReactElement<ButtonHTMLAttributes<HTMLButtonElement>>;
@@ -12,7 +12,8 @@ const HostDetailLayout = ({ rightContent, children }: HostDetailLayoutProps) => 
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
-  const host: hostInfoData | undefined = hostInfo.find(host => host.id === Number(id));
+  const hostChannelId = Number(id);
+  const { data } = useHostChannelInfo(hostChannelId);
 
   const handleBackClick = () => {
     navigate(-1);
@@ -29,12 +30,12 @@ const HostDetailLayout = ({ rightContent, children }: HostDetailLayoutProps) => 
           rightContent={rightContent}
           color="white"
         />
-        <div className="flex justify-center items-center px-6 md:px-10">
+        <div className="flex justify-start items-center px-6 md:px-10">
           <ProfileCircle profile="hostProfile" className="md:w-28 md:h-28 w-24 h-24" />
 
           <div className="flex flex-col gap-1 md:gap-3 ml-5 text-white">
-            <p className="text-lg md:text-xl font-bold">{host?.name}</p>
-            <p className="flex-wrap text-sm md:text-base">{host?.description}</p>
+            <p className="text-lg md:text-xl font-bold">{data?.result.hostChannelName}</p>
+            <p className="flex-wrap text-sm md:text-base">{data?.result.channelDescription}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 호스트 정보 수정 페이지

![스크린샷 2025-05-05 오후 3 29 19](https://github.com/user-attachments/assets/51677930-e5e9-4838-891d-0cf42f474af7)

![스크린샷 2025-05-05 오후 3 29 26](https://github.com/user-attachments/assets/7dc48be2-18de-486b-bb60-710153dce31e)

![스크린샷 2025-05-05 오후 3 29 40](https://github.com/user-attachments/assets/186a1e1b-4654-4e58-ae27-c54ca459269e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 호스트 채널 정보 조회 및 수정 기능이 추가되었습니다.
  - 호스트 채널 정보를 불러오는 커스텀 훅이 도입되었습니다.
  - 호스트 채널 정보 수정 기능을 위한 커스텀 훅이 추가되었습니다.

- **버그 수정**
  - 호스트 상세 정보, 정보 페이지, 레이아웃, 편집 페이지에서 정적 데이터 대신 실시간 데이터를 사용하도록 개선되었습니다.
  - 이벤트 목록, 멤버 목록 등에서 동적 데이터 구조에 맞게 필드명이 일관되게 변경되었습니다.

- **리팩터**
  - 페이지 및 레이아웃 컴포넌트가 정적 데이터 사용에서 동적 데이터 패칭 방식으로 전환되었습니다.

- **문서화**
  - 데이터 요청 및 응답 구조를 명확히 하는 타입 정의가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->