### PR TITLE
fix: 내 티켓 페이지 개선

### DIFF
--- a/src/features/event/model/FunnelContext.tsx
+++ b/src/features/event/model/FunnelContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, ReactNode, useContext, useState } from 'react';
 import { CreateEventRequest } from './event';
-import { HostCreationRequest } from './hostCreation';
+import { HostCreationRequest } from '../../host/model/host';
 
 export interface FunnelState {
   hostState: HostCreationRequest;

--- a/src/features/ticket/api/order.ts
+++ b/src/features/ticket/api/order.ts
@@ -1,5 +1,5 @@
-import { axiosClient } from "../../../shared/types/api/http-client"
-import { OrderTicketRequest } from "../model/orderInformation";
+import { axiosClient } from '../../../shared/types/api/http-client';
+import { OrderTicketRequest } from '../model/orderInformation';
 
 export const readTicket = {
   // 주문 티켓 전체 조회
@@ -24,6 +24,6 @@ export const orderTickets = async (data: OrderTicketRequest) => {
 
 // 티켓 취소
 export const cancelTickets = async (orderId: number) => {
-  const response = await axiosClient.post(`/orders/cancel?orderId=${orderId}`);
+  const response = await axiosClient.post(`/orders/${orderId}/cancel`);
   return response.data;
 };

--- a/src/features/ticket/hooks/useOrderHook.ts
+++ b/src/features/ticket/hooks/useOrderHook.ts
@@ -4,40 +4,40 @@ import { OrderTicketRequest } from '../model/orderInformation';
 
 // 주문 전체 조회
 export const useTicketOrders = (page: number = 0, size: number = 10) => {
-    return useQuery({
-        queryKey: ['ticketOrders', page, size],
-        queryFn: () => readTicket.getAll(page, size),
-    });
+  return useQuery({
+    queryKey: ['ticketOrders', page, size],
+    queryFn: () => readTicket.getAll(page, size),
+  });
 };
 
 // 주문 상세 조회
 export const useTicketOrderDetail = (orderId: number) => {
-    return useQuery({
-        queryKey: ['ticketOrderDetail', orderId],
-        queryFn: () => readTicket.getDetail(orderId),
-        enabled: !!orderId 
-    });
+  return useQuery({
+    queryKey: ['ticketOrderDetail', orderId],
+    queryFn: () => readTicket.getDetail(orderId),
+    enabled: !!orderId,
+  });
 };
 
 // 주문 취소
 export const useCancelTicket = () => {
-    return useMutation({
-        mutationFn: (orderId: number) => cancelTickets(orderId),
-        onSuccess: () => {
-            alert('티켓이 성공적으로 취소되었습니다.');
-        },
-        onError: () => {
-            alert('티켓 취소에 실패하였습니다.');
-        },
-    });
+  return useMutation({
+    mutationFn: (orderId: number) => cancelTickets(orderId),
+    onSuccess: () => {
+      alert('티켓이 성공적으로 취소되었습니다.');
+    },
+    onError: () => {
+      alert('티켓 취소에 실패하였습니다.');
+    },
+  });
 };
 
 // 티켓 구매
 export const useOrderTicket = () => {
-    return useMutation({
-        mutationFn: (data: OrderTicketRequest) => orderTickets(data),
-        onError: () => {
-            alert("티켓 구매 중 오류가 발생했습니다.");
-        },
-    });
+  return useMutation({
+    mutationFn: (data: OrderTicketRequest) => orderTickets(data),
+    onError: () => {
+      alert('티켓 구매 중 오류가 발생했습니다.');
+    },
+  });
 };

--- a/src/features/ticket/hooks/useTicketOptionHook.ts
+++ b/src/features/ticket/hooks/useTicketOptionHook.ts
@@ -1,53 +1,64 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { PersonalTicketOptionAnswerResponse, TicketOptionAnswerRequest, TicketOptionAnswerResponse, TicketOptionResponse, TicketResponse } from "../model/ticketInformation";
-import { createTicketOptionAnswers, readPersonalTicketOptionAnswers, readPurchaserAnswers, readTicketOptions } from "../api/ticketOption";
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+  PersonalTicketOptionAnswerResponse,
+  TicketOptionAnswerRequest,
+  TicketOptionAnswerResponse,
+  TicketOptionResponse,
+} from '../model/ticketInformation';
+import {
+  createTicketOptionAnswers,
+  readPersonalTicketOptionAnswers,
+  readPurchaserAnswers,
+  readTicketOptions,
+} from '../api/ticketOption';
+import { ApiResponse } from '../../../shared/types/api/apiResponse';
 
 // 티켓 옵션 조회
 export const useTicketOptions = (ticketId: number) => {
-    return useQuery<{ isSuccess: boolean; result: TicketOptionResponse[] }>({
-        queryKey: ['ticketOptions', ticketId],
-        queryFn: () => readTicketOptions(ticketId),
-        enabled: !!ticketId,
-    });
+  return useQuery<{ isSuccess: boolean; result: TicketOptionResponse[] }>({
+    queryKey: ['ticketOptions', ticketId],
+    queryFn: () => readTicketOptions(ticketId),
+    enabled: !!ticketId,
+  });
 };
 
 // 티켓 옵션 응답 전송
 export const useCreateTicketOptionAnswers = () => {
-    return useMutation<TicketResponse, Error, TicketOptionAnswerRequest>({
-        mutationFn: createTicketOptionAnswers,
-        onSuccess: () => {
-            console.log("티켓 옵션 응답 전송 성공");
-        },
-        onError: () => {
-            alert("티켓 옵션 응답 전송 중 오류가 발생했습니다.");
-        },
-    });
+  return useMutation<ApiResponse<null>, Error, TicketOptionAnswerRequest>({
+    mutationFn: createTicketOptionAnswers,
+    onSuccess: () => {
+      console.log('티켓 옵션 응답 전송 성공');
+    },
+    onError: () => {
+      alert('티켓 옵션 응답 전송 중 오류가 발생했습니다.');
+    },
+  });
 };
 
 // 티켓 옵션 응답 전체 조회
 export const usePurchaserAnswers = (ticketId: number | null) => {
-    return useQuery<{ isSuccess: boolean; result: TicketOptionAnswerResponse[] }>({
-        queryKey: ['purchaserAnswers', ticketId],
-        queryFn: () => {
-            if (ticketId === null) {
-                throw new Error("ticketId is required");
-            }
-            return readPurchaserAnswers(ticketId);
-        },
-        enabled: !!ticketId,
-    });
+  return useQuery<{ isSuccess: boolean; result: TicketOptionAnswerResponse[] }>({
+    queryKey: ['purchaserAnswers', ticketId],
+    queryFn: () => {
+      if (ticketId === null) {
+        throw new Error('ticketId is required');
+      }
+      return readPurchaserAnswers(ticketId);
+    },
+    enabled: !!ticketId,
+  });
 };
 
 // 티켓 옵션 응답 개별 조회
 export const usePersonalTicketOptionAnswers = (ticketId: number | null) => {
-    return useQuery<{ isSuccess: boolean; result: PersonalTicketOptionAnswerResponse[] }>({
-        queryKey: ['personalTicketOptionAnswers', ticketId],
-        queryFn: () => {
-            if (ticketId === null) {
-                throw new Error("ticketId is required");
-            }
-            return readPersonalTicketOptionAnswers(ticketId);
-        },
-        enabled: !!ticketId,
-    });
+  return useQuery<{ isSuccess: boolean; result: PersonalTicketOptionAnswerResponse[] }>({
+    queryKey: ['personalTicketOptionAnswers', ticketId],
+    queryFn: () => {
+      if (ticketId === null) {
+        throw new Error('ticketId is required');
+      }
+      return readPersonalTicketOptionAnswers(ticketId);
+    },
+    enabled: !!ticketId,
+  });
 };

--- a/src/features/ticket/model/Order.ts
+++ b/src/features/ticket/model/Order.ts
@@ -1,5 +1,27 @@
+import { OnlineType } from '../../../shared/types/baseEventType';
+
 export interface OrderTicketRequest {
-    ticketId: number;
-    eventId: number;
-    ticketCnt: number;
+  ticketId: number;
+  eventId: number;
+  ticketCnt: number;
+}
+
+export interface OrderTicketResponse {
+  id: number;
+  event: {
+    id: number;
+    bannerImageUrl: string;
+    title: string;
+    hostChannelName: string;
+    address: string;
+    startDate: string;
+    remainDays: string;
+    hashtags: string[];
+    onlineType: OnlineType;
+  };
+  ticketQrCode: string;
+  ticketName: string;
+  ticketPrice: number;
+  orderStatus: 'COMPLETED' | 'PENDING' | 'CANCELED';
+  checkIn: boolean;
 }

--- a/src/features/ticket/model/TicketContext.tsx
+++ b/src/features/ticket/model/TicketContext.tsx
@@ -19,8 +19,6 @@ export const TicketProvider = ({ children }: { children: ReactNode }) => {
     availableQuantity: 0,
     startDate: '',
     endDate: '',
-    startTime: '06:00',
-    endTime: '23:00',
   });
 
   const setTicketChannelId = (ticketChannelId: number) => {

--- a/src/features/ticket/model/ticketInformation.ts
+++ b/src/features/ticket/model/ticketInformation.ts
@@ -1,50 +1,43 @@
-export interface CreateTicketRequest {
-    eventId: number;
-    ticketType: string;
-    ticketName: string;
-    ticketDescription: string;
-    ticketPrice: number;
-    availableQuantity: number;
-    startDate: string;
-    endDate: string;
-    startTime: string;
-    endTime: string;
-}
+export type TicketOptionType = 'SINGLE' | 'MULTIPLE' | 'TEXT';
 
-export interface TicketResponse {
-    isSuccess: boolean;
-    code: string;
-    message: string;
-    result: string; // "ticketId: 2"
+export interface CreateTicketRequest {
+  eventId: number;
+  ticketType: string;
+  ticketName: string;
+  ticketDescription: string;
+  ticketPrice: number;
+  availableQuantity: number;
+  startDate: string;
+  endDate: string;
 }
 
 export interface ReadTicketResponse {
-    ticketId: number;
-    ticketName: string;
-    ticketDescription: string;
-    ticketPrice: number;
-    availableQuantity: number;
+  ticketId: number;
+  ticketName: string;
+  ticketDescription: string;
+  ticketPrice: number;
+  availableQuantity: number;
 }
 
 export interface TicketOptionChoice {
-    id: number;
-    name: string;
+  id: number;
+  name: string;
 }
 export interface TicketOptionResponse {
-    id: number;
-    name: string;
-    description: string;
-    type: 'SINGLE' | 'MULTIPLE' | 'TEXT';
-    isMandatory: boolean;
-    choices: TicketOptionChoice[];
+  id: number;
+  name: string;
+  description: string;
+  type: TicketOptionType;
+  isMandatory: boolean;
+  choices: TicketOptionChoice[];
 }
 
 // 티켓 옵션 응답 전송
 export interface TicketOptionAnswerRequest {
-    ticketOptionId: number;
-    answerText?: string;
-    ticketOptionChoiceId?: number;
-    ticketOptionChoiceIds?: number[];
+  ticketOptionId: number;
+  answerText?: string;
+  ticketOptionChoiceId?: number;
+  ticketOptionChoiceIds?: number[];
 }
 
 // 티켓 옵션 응답 전체 조회
@@ -55,10 +48,9 @@ export type TicketOptionAnswer = {
 export type TicketOptionAnswerResponse = {
   optionId: number;
   optionName: string;
-  optionType: 'SINGLE' | 'MULTIPLE' | 'TEXT';
+  optionType: TicketOptionType;
   answers: TicketOptionAnswer[];
 };
-
 
 // 티켓 옵션 응답 개별 조회
 export type PersonalTicketOptionAnswerResponse = {
@@ -71,6 +63,6 @@ export interface Order {
 }
 export interface OptionAnswer {
   optionName: string;
-  optionType: 'SINGLE' | 'MULTIPLE' | 'TEXT';
+  optionType: TicketOptionType;
   answer: string;
 }

--- a/src/pages/menu/ui/MyTicketPage.tsx
+++ b/src/pages/menu/ui/MyTicketPage.tsx
@@ -8,31 +8,13 @@ import completedImg from '../../../../public/assets/menu/Completed.svg';
 import pendingImg from '../../../../public/assets/menu/Pending.svg';
 import ticketImg from '../../../../public/assets/menu/Ticket.svg';
 import { useTicketOrders } from '../../../features/ticket/hooks/useOrderHook';
-type Ticket = {
-  id: number;
-  event: {
-    id: number;
-    bannerImageUrl: string;
-    title: string;
-    hostChannelName: string;
-    address: string;
-    startDate: string;
-    remainDays: string;
-    hashtags: string[];
-    onlineType: 'ONLINE' | 'OFFLINE'; // onlineType 추가
-  };
-  ticketQrCode: string;
-  ticketName: string;
-  ticketPrice: number;
-  orderStatus: 'COMPLETED' | 'PENDING' | 'CANCELED';
-  checkIn: boolean;
-};
+import { OrderTicketResponse } from '../../../features/ticket/model/Order';
 
 const MyTicketPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
+  const [selectedTicket, setSelectedTicket] = useState<OrderTicketResponse | null>(null);
   const { data, isLoading, isError } = useTicketOrders(0, 10);
-  const myTickets: Ticket[] = data?.result || [];
+  const myTickets: OrderTicketResponse[] = data?.result || [];
 
   return (
     <TicketHostLayout image={TicketLogo} centerContent="내 티켓" ticketPage={true}>

--- a/src/pages/menu/ui/MyTicketPage.tsx
+++ b/src/pages/menu/ui/MyTicketPage.tsx
@@ -9,17 +9,35 @@ import pendingImg from '../../../../public/assets/menu/Pending.svg';
 import ticketImg from '../../../../public/assets/menu/Ticket.svg';
 import { useTicketOrders } from '../../../features/ticket/hooks/useOrderHook';
 import { OrderTicketResponse } from '../../../features/ticket/model/Order';
+import EmailDeleteModal from '../../../widgets/dashboard/ui/email/EmailDeleteModal';
+import TertiaryButton from '../../../../design-system/ui/buttons/TertiaryButton';
 
 const MyTicketPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedTicket, setSelectedTicket] = useState<OrderTicketResponse | null>(null);
+  const [isCancelMode, setIsCancelMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
   const { data, isLoading, isError } = useTicketOrders(0, 10);
   const myTickets: OrderTicketResponse[] = data?.result || [];
 
   return (
-    <TicketHostLayout image={TicketLogo} centerContent="내 티켓" ticketPage={true}>
+    <TicketHostLayout image={TicketLogo} centerContent="내 티켓" ticketPage={true} isCancelMode={isCancelMode}>
+      {!isModalOpen && (
+        <div className="flex justify-end mx-6 mt-24">
+          <TertiaryButton
+            label={isCancelMode ? '선택 완료' : '티켓 취소'}
+            type="button"
+            color="pink"
+            size="small"
+            onClick={() => setIsCancelMode(prev => !prev)}
+          />
+        </div>
+      )}
+
       {/* 이벤트 카드 목록 */}
-      <div className="grid grid-cols-2 gap-4 mx-6 mt-28 md:grid-cols-2 lg:grid-cols-2 pb-4">
+      <div className="grid grid-cols-2 gap-4 mx-6 mt-2 md:grid-cols-2 lg:grid-cols-2 pb-4">
         {isLoading ? (
           <p className="col-span-2 text-center text-sm md:text-base">티켓을 불러오는 중입니다...</p>
         ) : isError ? (
@@ -37,9 +55,18 @@ const MyTicketPage = () => {
               location={ticket.event.address}
               hashtags={ticket.event.hashtags}
               onClick={() => {
-                setSelectedTicket(ticket);
-                setIsModalOpen(true);
+                if (isCancelMode) {
+                  setSelectedIds(prev =>
+                    prev.includes(ticket.id) ? prev.filter(id => id !== ticket.id) : [...prev, ticket.id]
+                  );
+                } else {
+                  setSelectedTicket(ticket);
+                  setIsModalOpen(true);
+                }
               }}
+              className={`transition-transform duration-200 ${
+                isCancelMode && selectedIds.includes(ticket.id) ? 'scale-95 border-2 border-pink-400' : ''
+              }`}
             >
               <div className="flex items-center text-xs text-gray-500">
                 <img src={ticketImg} alt="티켓" className="w-3 h-3 mr-1" />
@@ -81,6 +108,22 @@ const MyTicketPage = () => {
             />
           </div>
         </div>
+      )}
+
+      {isDeleteModalOpen && (
+        <EmailDeleteModal
+          mainText={`총 ${selectedIds.length}개의 티켓을 취소하시겠습니까? 취소 후에는 복구가 불가능합니다.`}
+          approveButtonText="티켓 취소"
+          rejectButtonText="뒤로가기"
+          onClose={() => setIsDeleteModalOpen(false)}
+          onClick={() => {
+            /* cancelOrderTicket(selectedIds).then(() => {
+              setIsDeleteModalOpen(false);
+              setIsCancelMode(false);
+              setSelectedIds([]);
+            }); */
+          }}
+        />
       )}
     </TicketHostLayout>
   );

--- a/src/pages/menu/ui/MyTicketPage.tsx
+++ b/src/pages/menu/ui/MyTicketPage.tsx
@@ -23,6 +23,31 @@ const MyTicketPage = () => {
   const { data, isLoading, isError } = useTicketOrders(0, 10);
   const { mutate: cancelTicket } = useCancelTicket();
 
+  const handleCancelButtonClick = () => {
+    if (isCancelMode) {
+      if (selectedIds.length === 0) {
+        setIsCancelMode(false);
+        return;
+      }
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const invalidTickets = tickets.filter(
+        ticket => selectedIds.includes(ticket.id) && new Date(ticket.event.startDate) <= today
+      );
+
+      if (invalidTickets.length > 0) {
+        alert('이미 시작된 이벤트의 티켓은 취소할 수 없습니다.');
+        return;
+      }
+
+      setIsDeleteModalOpen(true);
+    } else {
+      setIsCancelMode(true);
+    }
+  };
+
   useEffect(() => {
     if (data?.result) {
       setTickets(data.result);
@@ -38,17 +63,7 @@ const MyTicketPage = () => {
             type="button"
             color="pink"
             size="small"
-            onClick={() => {
-              if (isCancelMode) {
-                if (selectedIds.length > 0) {
-                  setIsDeleteModalOpen(true);
-                } else {
-                  alert('취소할 티켓을 선택해주세요.');
-                }
-              } else {
-                setIsCancelMode(true);
-              }
-            }}
+            onClick={handleCancelButtonClick}
           />
         </div>
       )}

--- a/src/pages/menu/ui/MyTicketPage.tsx
+++ b/src/pages/menu/ui/MyTicketPage.tsx
@@ -1,13 +1,13 @@
 import TicketHostLayout from '../../../shared/ui/backgrounds/TicketHostLayout';
 import TicketLogo from '../../../../public/assets/menu/TicketLogo.svg';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import QrModal from '../../../../design-system/ui/modals/QrModal';
 import QRbackground from '../../../../design-system/icons/QRbackground.svg';
 import EventCard from '../../../shared/ui/EventCard';
 import completedImg from '../../../../public/assets/menu/Completed.svg';
 import pendingImg from '../../../../public/assets/menu/Pending.svg';
 import ticketImg from '../../../../public/assets/menu/Ticket.svg';
-import { useTicketOrders } from '../../../features/ticket/hooks/useOrderHook';
+import { useCancelTicket, useTicketOrders } from '../../../features/ticket/hooks/useOrderHook';
 import { OrderTicketResponse } from '../../../features/ticket/model/Order';
 import EmailDeleteModal from '../../../widgets/dashboard/ui/email/EmailDeleteModal';
 import TertiaryButton from '../../../../design-system/ui/buttons/TertiaryButton';
@@ -18,9 +18,16 @@ const MyTicketPage = () => {
   const [isCancelMode, setIsCancelMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [tickets, setTickets] = useState<OrderTicketResponse[]>([]);
 
   const { data, isLoading, isError } = useTicketOrders(0, 10);
-  const myTickets: OrderTicketResponse[] = data?.result || [];
+  const { mutate: cancelTicket } = useCancelTicket();
+
+  useEffect(() => {
+    if (data?.result) {
+      setTickets(data.result);
+    }
+  }, [data]);
 
   return (
     <TicketHostLayout image={TicketLogo} centerContent="내 티켓" ticketPage={true} isCancelMode={isCancelMode}>
@@ -31,7 +38,17 @@ const MyTicketPage = () => {
             type="button"
             color="pink"
             size="small"
-            onClick={() => setIsCancelMode(prev => !prev)}
+            onClick={() => {
+              if (isCancelMode) {
+                if (selectedIds.length > 0) {
+                  setIsDeleteModalOpen(true);
+                } else {
+                  alert('취소할 티켓을 선택해주세요.');
+                }
+              } else {
+                setIsCancelMode(true);
+              }
+            }}
           />
         </div>
       )}
@@ -42,8 +59,8 @@ const MyTicketPage = () => {
           <p className="col-span-2 text-center text-sm md:text-base">티켓을 불러오는 중입니다...</p>
         ) : isError ? (
           <p className="col-span-2 text-center text-sm md:text-base text-red-500">티켓을 불러오는데 실패했습니다.</p>
-        ) : myTickets.length > 0 ? (
-          myTickets.map(ticket => (
+        ) : tickets.length > 0 ? (
+          tickets.map(ticket => (
             <EventCard
               key={ticket.id}
               id={ticket.id}
@@ -117,11 +134,12 @@ const MyTicketPage = () => {
           rejectButtonText="뒤로가기"
           onClose={() => setIsDeleteModalOpen(false)}
           onClick={() => {
-            /* cancelOrderTicket(selectedIds).then(() => {
+            Promise.all(selectedIds.map(id => cancelTicket(id))).then(() => {
+              setTickets(prev => prev.filter(ticket => !selectedIds.includes(ticket.id)));
               setIsDeleteModalOpen(false);
               setIsCancelMode(false);
               setSelectedIds([]);
-            }); */
+            });
           }}
         />
       )}

--- a/src/shared/ui/EventCard.tsx
+++ b/src/shared/ui/EventCard.tsx
@@ -20,6 +20,7 @@ interface EventCardProps {
   location: string;
   hashtags: string[];
   onClick?: () => void;
+  className?: string;
   children?: React.ReactNode;
   isDelete?: boolean;
   onDeleteSuccess?: (eventId: number) => void;
@@ -35,6 +36,7 @@ const EventCard = ({
   location,
   hashtags,
   onClick,
+  className,
   children,
   isDelete = false,
   onDeleteSuccess,
@@ -49,7 +51,7 @@ const EventCard = ({
   return (
     <div
       onClick={onClick}
-      className="w-full max-w-full h-full min-h-[240px] md:min-h-[300px] max-h-full p-2 md:p-4 bg-white rounded-lg shadow-md cursor-pointer flex flex-col justify-between"
+      className={`w-full max-w-full h-full min-h-[240px] md:min-h-[300px] max-h-full p-2 md:p-4 bg-white rounded-lg shadow-md cursor-pointer flex flex-col justify-between ${className}`}
     >
       {/* 이미지 */}
       <img src={img} alt={eventTitle} className="object-cover w-full rounded-md sm:h-20 md:h-24 lg:h-28" />

--- a/src/shared/ui/backgrounds/TicketHostLayout.tsx
+++ b/src/shared/ui/backgrounds/TicketHostLayout.tsx
@@ -8,9 +8,16 @@ interface TicketHostLayoutProps {
   children: React.ReactNode;
   centerContent: string;
   ticketPage?: boolean;
+  isCancelMode?: boolean;
 }
 
-const TicketHostLayout = ({ image, children, centerContent, ticketPage = true }: TicketHostLayoutProps) => {
+const TicketHostLayout = ({
+  image,
+  children,
+  centerContent,
+  ticketPage = true,
+  isCancelMode = false,
+}: TicketHostLayoutProps) => {
   const navigate = useNavigate();
   const handleBackClick = () => {
     navigate(-1);
@@ -46,7 +53,7 @@ const TicketHostLayout = ({ image, children, centerContent, ticketPage = true }:
 
           {ticketPage && (
             <div className="absolute left-1/2 transform -translate-x-1/2 top-[calc(150%)] text-placeholderText text-center text-sm whitespace-nowrap">
-              티켓을 누르면 입장을 위한 QR코드를 확인할 수 있습니다.
+              {isCancelMode ? '취소할 티켓을 선택해주세요' : '티켓을 누르면 입장을 위한 QR코드를 확인할 수 있습니다.'}
             </div>
           )}
 


### PR DESCRIPTION
* 주문 취소 API 에러 수정

* 내 티켓 페이지 주문 취소 기능 추가

<img width="511" alt="스크린샷 2025-05-29 오후 5 30 07" src="https://github.com/user-attachments/assets/4bb05760-080d-4b14-a99b-e62e42995079" />

<img width="511" alt="스크린샷 2025-05-29 오후 5 30 13" src="https://github.com/user-attachments/assets/815b6cda-787c-48d2-9e8f-2792aa4a40e1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 마이티켓 페이지에서 여러 티켓을 선택해 한 번에 취소할 수 있는 기능이 추가되었습니다.
  - 티켓 취소 시 확인 모달이 표시되어, 선택한 티켓을 안전하게 취소할 수 있습니다.
  - 티켓 리스트가 개별적으로 관리되어, 취소 후 실시간으로 갱신됩니다.

- **UI 개선**
  - 티켓 선택 및 취소 모드에서 시각적 강조 효과가 적용되어, 선택된 티켓을 쉽게 구분할 수 있습니다.
  - 티켓 레이아웃과 카드 컴포넌트에 외부 스타일 클래스 적용이 가능해졌습니다.
  - 티켓 페이지 상단 안내 문구가 취소 모드에 따라 동적으로 변경됩니다.

- **기타 개선**
  - 일부 입력값 및 타입이 명확하게 개선되어 안정성이 향상되었습니다.
  - 티켓 옵션 타입이 통합되어 코드 일관성이 높아졌습니다.
  - 티켓 취소 API 경로가 RESTful 방식으로 변경되어 안정성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->