### PR TITLE
fix: 중복되는 티켓 옵션 타입 수정

### DIFF
--- a/src/features/ticket/api/ticketOption.ts
+++ b/src/features/ticket/api/ticketOption.ts
@@ -1,4 +1,6 @@
 import { axiosClient } from "../../../shared/types/api/http-client";
+import { ApiResponse } from '../../../shared/types/api/apiResponse';
+import { TicketOptionRequest, TicketOptionTypeResponse } from '../model/ticketOption';
 import { PersonalTicketOptionAnswerResponse, TicketOptionAnswerRequest, TicketOptionAnswerResponse, TicketOptionResponse } from "../model/ticketInformation";
 
 // 티켓 옵션 조회
@@ -28,12 +30,11 @@ export const readPersonalTicketOptionAnswers = async (ticketId: number): Promise
   });
   return response.data;
 };
-import { TicketOptionRequest, TicketOptionResponse } from '../model/ticketOption';
-import { ApiResponse } from '../../../shared/types/api/apiResponse';
+
 
 // 티켓 옵션 생성
-export const createTicketOption = async (data: TicketOptionRequest): Promise<TicketOptionResponse> => {
-  const response = await axiosClient.post<TicketOptionResponse>('/ticket-options', data);
+export const createTicketOption = async (data: TicketOptionRequest): Promise<TicketOptionTypeResponse> => {
+  const response = await axiosClient.post<TicketOptionTypeResponse>('/ticket-options', data);
   return response.data;
 };
 
@@ -53,20 +54,20 @@ export const deleteTicketOption = async (ticketOptionId: number): Promise<ApiRes
 };
 
 // 티켓 옵션 목록 조회
-export const getTicketOptions = async (eventId: number): Promise<TicketOptionResponse> => {
-  const response = await axiosClient.get<TicketOptionResponse>(`/ticket-options/events/${eventId}`);
+export const getTicketOptions = async (eventId: number): Promise<TicketOptionTypeResponse> => {
+  const response = await axiosClient.get<TicketOptionTypeResponse>(`/ticket-options/events/${eventId}`);
   return response.data;
 };
 
 // 티켓에 부착된 옵션 목록 조회
-export const getAttachedTicketOptions = async (ticketId: number): Promise<TicketOptionResponse> => {
-  const response = await axiosClient.get<TicketOptionResponse>(`ticket-options/tickets/${ticketId}`);
+export const getAttachedTicketOptions = async (ticketId: number): Promise<TicketOptionTypeResponse> => {
+  const response = await axiosClient.get<TicketOptionTypeResponse>(`ticket-options/tickets/${ticketId}`);
   return response.data;
 };
 
 // 티켓 옵션 상세 조회
-export const getTicketOptionDetail = async (ticketOptionId: number): Promise<TicketOptionResponse> => {
-  const response = await axiosClient.get<TicketOptionResponse>(`/ticket-options/${ticketOptionId}`);
+export const getTicketOptionDetail = async (ticketOptionId: number): Promise<TicketOptionTypeResponse> => {
+  const response = await axiosClient.get<TicketOptionTypeResponse>(`/ticket-options/${ticketOptionId}`);
   return response.data;
 };
 

--- a/src/features/ticket/hooks/useTicketOptionHook.ts
+++ b/src/features/ticket/hooks/useTicketOptionHook.ts
@@ -1,3 +1,7 @@
+import { ApiResponse } from '../../../shared/types/api/apiResponse';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { TicketOptionRequest, TicketOptionTypeResponse } from '../model/ticketOption';
 import {
   PersonalTicketOptionAnswerResponse,
   TicketOptionAnswerRequest,
@@ -10,7 +14,17 @@ import {
   readPurchaserAnswers,
   readTicketOptions,
 } from '../api/ticketOption';
-import { ApiResponse } from '../../../shared/types/api/apiResponse';
+import {
+  getTicketOptions,
+  createTicketOption,
+  modifyTicketOption,
+  deleteTicketOption,
+  getAttachedTicketOptions,
+  getTicketOptionDetail,
+  attachTicketOption,
+  detachTicketOption,
+} from '../api/ticketOption';
+
 
 // 티켓 옵션 조회
 export const useTicketOptions = (ticketId: number) => {
@@ -62,21 +76,7 @@ export const usePersonalTicketOptionAnswers = (ticketId: number | null) => {
   });
 };
 
-import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import {
-  getTicketOptions,
-  createTicketOption,
-  modifyTicketOption,
-  deleteTicketOption,
-  getAttachedTicketOptions,
-  getTicketOptionDetail,
-  attachTicketOption,
-  detachTicketOption,
-} from '../api/ticketOption';
-import { TicketOptionRequest, TicketOptionResponse } from '../model/ticketOption';
-
-// 티켓 옵션 생성 훅
+// 티켓 옵션 생성 훅 
 export const useCreateTicketOptionMutation = () => {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -138,7 +138,7 @@ export const useGetTicketOptions = () => {
   const { id } = useParams();
   const eventId = Number(id);
 
-  return useQuery<TicketOptionResponse>({
+  return useQuery<TicketOptionTypeResponse>({
     queryKey: ['ticketOptions', id],
     queryFn: () => getTicketOptions(eventId),
     enabled: !!id,
@@ -147,7 +147,7 @@ export const useGetTicketOptions = () => {
 
 // 티켓에 부착된 옵션 목록 조회 훅
 export const useGetAttachedTicketOptions = (ticketId: number) => {
-  return useQuery<TicketOptionResponse>({
+  return useQuery<TicketOptionTypeResponse>({
     queryKey: ['attachedTicketOptions', ticketId],
     queryFn: () => getAttachedTicketOptions(ticketId),
     enabled: !!ticketId,
@@ -156,7 +156,7 @@ export const useGetAttachedTicketOptions = (ticketId: number) => {
 
 // 티켓 옵션 상세 조회 훅
 export const useGetTicketOptionDetail = (ticketOptionId: number) => {
-  return useQuery<TicketOptionResponse>({
+  return useQuery<TicketOptionTypeResponse>({
     queryKey: ['ticketOptionDetail', ticketOptionId],
     queryFn: () => getTicketOptionDetail(ticketOptionId),
     enabled: !!ticketOptionId,

--- a/src/features/ticket/model/ticketOption.ts
+++ b/src/features/ticket/model/ticketOption.ts
@@ -57,4 +57,4 @@ export interface TicketOptionsType {
   }[];
 }
 
-export interface TicketOptionResponse extends ApiResponse<TicketOptionsType> {}
+export interface TicketOptionTypeResponse extends ApiResponse<TicketOptionsType> {}


### PR DESCRIPTION
1. src/features/ticket/api/ticketOption.ts 파일에서 TicketOptionResponse 타입이 충돌이 일어남
2. src/features/ticket/model/ticketOption.ts 파일에서 TicketOptionResponse을 TicketOptionTypeResponse로 수정
3. src/features/ticket/api/ticketOption.ts 파일에서 티켓 옵션 부착 페이지에 해당하는 TicketOptionResponse 만 TicketOptionTypeResponse로 수정
4. src/features/ticket/hooks/useTicketOptionHook.ts 파일에서 티켓 옵션 부착 페이지에 해당하는 TicketOptionResponse 만 TicketOptionTypeResponse로 수정
5. src/features/ticket/model/ticketOptionReducer.ts 파일에서 타입 이름 수정