### PR TITLE
fix: 모든 페이지 기능/API 에러 해결

### DIFF
--- a/src/entities/event/api/event.ts
+++ b/src/entities/event/api/event.ts
@@ -7,7 +7,7 @@ import { EventItem, PaginationParams } from '../model/eventDetail';
 export const eventDetail = async (dto: EventDetailRequest) => {
   const response = await axiosClient.get(`/events/${dto.eventId}`, {
     params: { userId: dto.userId },
-    headers: { skipAuth: true },
+    headers: { isPublicApi: true },
   });
   return response.data;
 };
@@ -25,7 +25,7 @@ export const getAllEventsInfinite = async ({
   params.append('size', size.toString());
 
   const response = await axiosClient.get<ApiResponse<EventItem[]>>(`/events?${params.toString()}`, {
-    headers: { skipAuth: true },
+    headers: { isPublicApi: true },
   });
 
   const items = response.data.result ?? [];
@@ -49,7 +49,7 @@ export const getCategoryEventsInfinite = async ({
   params.append('size', size.toString());
 
   const response = await axiosClient.get<ApiResponse<EventItem[]>>(`/events/categories?${params.toString()}`, {
-    headers: { skipAuth: true },
+    headers: { isPublicApi: true },
   });
 
   const items = response.data.result ?? [];
@@ -63,7 +63,7 @@ export const getCategoryEventsInfinite = async ({
 // 태그별 이벤트 목록 조회 (최신, 인기, 마감 / 기본 정보)
 export const getEventByTag = async (tag: TagType, { page, size }: PaginationParams): Promise<EventItem[]> => {
   const response = await axiosClient.get<{ result: EventItem[] }>(`/events?tags=${tag}&page=${page}&size=${size}`, {
-    headers: { skipAuth: true },
+    headers: { isPublicApi: true },
   });
   return response.data.result || [];
 };
@@ -76,7 +76,7 @@ export const getEventByCategory = async (
   const response = await axiosClient.get<EventItem[]>(
     `/events/category?category=${category}&page=${page}&size=${size}`,
     {
-      headers: { skipAuth: true },
+      headers: { isPublicApi: true },
     }
   );
   return response.data;

--- a/src/features/dashboard/ui/MultiplePieCharts.tsx
+++ b/src/features/dashboard/ui/MultiplePieCharts.tsx
@@ -23,7 +23,7 @@ const MultiplePieCharts = ({ responses }: MultiplePieChartsProps) => {
   }
 
   return (
-    <div className="grid grid-cols-1 gap-6 p-4 bg-white mb-4">
+    <div className="grid grid-cols-1 gap-6 p-4 bg-white">
       {responses.map((option, index) => {
         const data = aggregateAnswers(option.ticketOptionAnswers);
 

--- a/src/features/dashboard/ui/MultiplePieCharts.tsx
+++ b/src/features/dashboard/ui/MultiplePieCharts.tsx
@@ -1,5 +1,5 @@
 import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
-import { TicketOption, TicketOptionAnswer} from '../../ticket/model/ticketInformation';
+import { TicketOption, TicketOptionAnswer } from '../../ticket/model/ticketInformation';
 
 const COLORS = ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40'];
 
@@ -23,7 +23,7 @@ const MultiplePieCharts = ({ responses }: MultiplePieChartsProps) => {
   }
 
   return (
-    <div className="grid grid-cols-1 gap-6 p-4">
+    <div className="grid grid-cols-1 gap-6 p-4 bg-white mb-4">
       {responses.map((option, index) => {
         const data = aggregateAnswers(option.ticketOptionAnswers);
 
@@ -32,16 +32,7 @@ const MultiplePieCharts = ({ responses }: MultiplePieChartsProps) => {
             <h3 className="mb-2 font-semibold text-lg">{option.optionName}</h3>
             <ResponsiveContainer width="100%" height={300}>
               <PieChart>
-                <Pie
-                  data={data}
-                  dataKey="value"
-                  nameKey="name"
-                  cx="50%"
-                  cy="50%"
-                  outerRadius={80}
-                  label
-                  stroke="none"
-                >
+                <Pie data={data} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80} label stroke="none">
                   {data.map((_, i) => (
                     <Cell key={`cell-${i}`} fill={COLORS[i % COLORS.length]} />
                   ))}

--- a/src/features/dashboard/ui/ParicipantCard.tsx
+++ b/src/features/dashboard/ui/ParicipantCard.tsx
@@ -12,38 +12,36 @@ interface ParticipantCardProps {
 }
 
 const ParticipantCard = ({ participant, onCheckClick }: ParticipantCardProps) => {
-
   const { mutate: approveParticipant } = useApproveParticipants(participant.orderId);
 
   return (
     <div className="flex items-center justify-between w-full text-xs bg-white px-2 md:px-3 py-2 shadow-sm">
       <div className="flex gap-2 md:gap-3">
-        <div className="flex items-center gap-4 md:gap-6 text-11 md:text-12">
-          <p>{participant.orderId}</p>
+        <div className="flex items-center gap-8 md:gap-20 text-10 md:text-12">
+          <p className="ml-3">{participant.orderId}</p>
           <div className="flex flex-col">
             <p>이름: {participant.participant}</p>
             <p>이메일 주소: {participant.email}</p>
             <p>휴대폰 번호: {participant.phoneNumber}</p>
-            <div>구매 일자: {formatDate(participant.purchaseDate)} {formatTime(participant.purchaseDate)}</div>
+            <div>
+              구매 일자: {formatDate(participant.purchaseDate)} {formatTime(participant.purchaseDate)}
+            </div>
             <p>티켓 이름: {participant.ticketName}</p>
           </div>
         </div>
       </div>
       <div className="flex items-center justify-center gap-3">
-        {
-          <SecondaryButton
-            label="확인하기"
-            color="pink"
-            size="small"
-            onClick={onCheckClick}
-          />
-        }
-        {participant.checkedIn ? <p className="text-[#888686]">완료</p> : <p className="text-[#888686]">미완료</p>}
+        {<SecondaryButton label="확인하기" color="pink" size="small" onClick={onCheckClick} />}
+        {participant.checkedIn ? (
+          <p className="text-[#888686] text-10 md:text-12">완료</p>
+        ) : (
+          <p className="text-[#888686] text-10 md:text-12">미완료</p>
+        )}
 
         {participant.approved ? (
-          <p className="text-[#888686]">승인됨</p>
+          <p className="text-[#888686] text-10 md:text-12">승인됨</p>
         ) : participant.ticketType === 'FIRST_COME' ? (
-          <p className="text-[#888686] invisible">승인됨</p>
+          <p className="text-[#888686] invisible text-10 md:text-12">승인됨</p>
         ) : (
           <TertiaryButton
             label="승인"

--- a/src/features/dashboard/ui/PariticipantsList.tsx
+++ b/src/features/dashboard/ui/PariticipantsList.tsx
@@ -19,7 +19,7 @@ const ParticipantsList = ({ listType, selectedFilter = [], participants }: Parti
     selectedTicketId,
     selectedOrderId,
     setSelectedTicketId,
-    setSelectedOrderId
+    setSelectedOrderId,
   } = useParticipantStore();
 
   const { data } = usePersonalTicketOptionAnswers(selectedTicketId);
@@ -38,9 +38,7 @@ const ParticipantsList = ({ listType, selectedFilter = [], participants }: Parti
       return;
     }
 
-    const order = data.result
-      .flatMap(user => user.orders)
-      .find(order => order.orderId === selectedOrderId);
+    const order = data.result.flatMap(user => user.orders).find(order => order.orderId === selectedOrderId);
 
     if (!order) {
       alert('응답 데이터가 없습니다.');
@@ -68,7 +66,7 @@ const ParticipantsList = ({ listType, selectedFilter = [], participants }: Parti
     <div className="flex flex-col gap-2 mb-4">
       <div className="flex justify-between text-xs text-[#888686] bg-white shadow-sm px-2 md:px-3 py-3 rounded-t-lg">
         <div className="flex gap-2 md:gap-3">
-          <div className="flex items-center gap-15 md:gap-24">
+          <div className="flex items-center gap-3 md:gap-16">
             <p>주문 번호</p>
             <p>참여자 정보</p>
           </div>

--- a/src/features/dashboard/ui/ResponsesList.tsx
+++ b/src/features/dashboard/ui/ResponsesList.tsx
@@ -14,85 +14,66 @@ interface ResponsesListProps {
 const ResponsesList = ({ listType, ticketOptionResponses, ticketId }: ResponsesListProps) => {
   const { data, isLoading, error } = usePersonalTicketOptionAnswers(ticketId);
 
-  const {
-    currentIndex,
-    setCurrentIndex,
-  } = useResponseStore();
+  const { currentIndex, setCurrentIndex } = useResponseStore();
 
   useEffect(() => {
     setCurrentIndex(() => 0);
   }, [listType, setCurrentIndex]);
 
-  const renderTextResponses = (responses: TicketOption[]) => {
-    const textResponses = responses.filter((res) => res.optionType === 'TEXT');
-    if (textResponses.length === 0) return null;
-
-    return (
-      <>
-        {textResponses.map((textResponse, idx) => (
-          <div className="bg-white p-4 flex flex-col gap-2 mb-4" key={`${textResponse.optionId}-${idx}`}>
-            <div className="flex justify-between items-center text-xs bg-white px-2 md:px-3 py-3">
-              <p className="text-base font-bold">{textResponse.optionName}</p>
-              <p>응답 {textResponse.ticketOptionAnswers.length}개</p>
-            </div>
-
-            {textResponse.ticketOptionAnswers.length === 0 ? (
-              <p>응답이 없습니다.</p>
-            ) : (
-              <div className="h-full max-h-48 overflow-y-auto space-y-2">
-                {textResponse.ticketOptionAnswers.map((answer) => (
-                  <div
-                    className="flex justify-between text-xs bg-gray-100 shadow-sm px-2 md:px-3 py-3 gap-2"
-                    key={answer.id}
-                  >
-                    <p>{answer.answer}</p>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        ))}
-      </>
-    );
-  };
-
   const renderList = () => {
     switch (listType) {
-      case 'summary':
-        {
-          const filteredResponses = ticketOptionResponses.filter(
-            (option) => option.optionType !== 'TEXT'
-          );
-          return (
-            <>
-              <div className="flex justify-center">
-                <div style={{ minWidth: '300px', maxWidth: '600px', width: '100%' }}>
-                  <MultiplePieCharts responses={filteredResponses} />
+      case 'summary': {
+        return (
+          <div className="space-y-4">
+            {ticketOptionResponses.map(option => {
+              if (option.optionType === 'TEXT') {
+                return (
+                  <div key={option.optionId} className="bg-white p-4 rounded shadow-sm">
+                    <div className="flex justify-between items-center text-xs px-2 md:px-3 py-3">
+                      <p className="text-base font-bold">{option.optionName}</p>
+                      <p>응답 {option.ticketOptionAnswers.length}개</p>
+                    </div>
+                    {option.ticketOptionAnswers.length === 0 ? (
+                      <p className="text-sm text-gray-500">응답이 없습니다.</p>
+                    ) : (
+                      <div className="max-h-48 overflow-y-auto space-y-2">
+                        {option.ticketOptionAnswers.map(answer => (
+                          <div key={answer.id} className="text-xs bg-gray-100 px-3 py-2 rounded">
+                            {answer.answer}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              }
+              return (
+                <div key={option.optionId} className="flex justify-center">
+                  <div className="w-full max-w-[600px] min-w-[300px]">
+                    <MultiplePieCharts responses={[option]} />
+                  </div>
                 </div>
-              </div>
-              {renderTextResponses(ticketOptionResponses)}
-            </>
-          );
-        }
+              );
+            })}
+          </div>
+        );
+      }
 
-      case 'individual':
-        {
-          if (isLoading) return <p>로딩 중...</p>;
-          if (error || !data?.result) return <p>데이터를 불러오지 못했습니다.</p>;
-          const allOrders = data.result.flatMap(user => user.orders);
-          return (
-            <IndividualResponseViewer
-              orders={allOrders}
-              currentIndex={currentIndex}
-              setCurrentIndex={setCurrentIndex}
-            />
-          );
-        }
+      case 'individual': {
+        if (isLoading) return <p>로딩 중...</p>;
+        if (error || !data?.result) return <p>데이터를 불러오지 못했습니다.</p>;
+        const allOrders = data.result.flatMap(user => user.orders);
+        return (
+          <IndividualResponseViewer orders={allOrders} currentIndex={currentIndex} setCurrentIndex={setCurrentIndex} />
+        );
+      }
+
       default:
         return null;
     }
   };
+
   return <div>{renderList()}</div>;
 };
-export default ResponsesList;
 
+export default ResponsesList;

--- a/src/features/event/ui/DatePicker.tsx
+++ b/src/features/event/ui/DatePicker.tsx
@@ -27,10 +27,12 @@ const EventDatePicker = ({
   isLabel = false,
 }: DatePickerProps) => {
   const [startDate, setStartDate] = useState<Date | null>(
-    eventState?.startDate ? new Date(eventState.startDate) : new Date()
+    eventState?.startDate ? new Date(eventState.startDate) : initialStartDate ? new Date(initialStartDate) : null
   );
-  const [endDate, setEndDate] = useState<Date | null>(eventState?.endDate ? new Date(eventState.endDate) : new Date());
 
+  const [endDate, setEndDate] = useState<Date | null>(
+    eventState?.endDate ? new Date(eventState.endDate) : initialEndDate ? new Date(initialEndDate) : null
+  );
   const [startTime, setStartTime] = useState<string>('06:00');
   const [endTime, setEndTime] = useState<string>('23:00');
 
@@ -39,18 +41,18 @@ const EventDatePicker = ({
     const end = eventState?.endDate || initialEndDate;
 
     if (start && !startDate) {
-      const startDate = new Date(start);
-      setStartDate(startDate);
-      const hours = startDate.getHours().toString().padStart(2, '0');
-      const minutes = startDate.getMinutes().toString().padStart(2, '0');
+      const startDateObj = new Date(start);
+      setStartDate(prev => prev ?? startDateObj);
+      const hours = startDateObj.getHours().toString().padStart(2, '0');
+      const minutes = startDateObj.getMinutes().toString().padStart(2, '0');
       setStartTime(`${hours}:${minutes}`);
     }
 
     if (end && !endDate) {
-      const endDate = new Date(end);
-      setEndDate(endDate);
-      const hours = endDate.getHours().toString().padStart(2, '0');
-      const minutes = endDate.getMinutes().toString().padStart(2, '0');
+      const endDateObj = new Date(end);
+      setEndDate(prev => prev ?? endDateObj);
+      const hours = endDateObj.getHours().toString().padStart(2, '0');
+      const minutes = endDateObj.getMinutes().toString().padStart(2, '0');
       setEndTime(`${hours}:${minutes}`);
     }
   }, [eventState, initialStartDate, initialEndDate]);

--- a/src/features/event/ui/DatePicker.tsx
+++ b/src/features/event/ui/DatePicker.tsx
@@ -27,11 +27,11 @@ const EventDatePicker = ({
   isLabel = false,
 }: DatePickerProps) => {
   const [startDate, setStartDate] = useState<Date | null>(
-    eventState?.startDate ? new Date(eventState.startDate) : initialStartDate ? new Date(initialStartDate) : null
+    eventState?.startDate ? new Date(eventState.startDate) : initialStartDate ? new Date(initialStartDate) : new Date()
   );
 
   const [endDate, setEndDate] = useState<Date | null>(
-    eventState?.endDate ? new Date(eventState.endDate) : initialEndDate ? new Date(initialEndDate) : null
+    eventState?.endDate ? new Date(eventState.endDate) : initialEndDate ? new Date(initialEndDate) : new Date()
   );
   const [startTime, setStartTime] = useState<string>('06:00');
   const [endTime, setEndTime] = useState<string>('23:00');

--- a/src/features/event/ui/EventList.tsx
+++ b/src/features/event/ui/EventList.tsx
@@ -67,27 +67,36 @@ const EventList = ({ category, tag }: EventListComponentProps) => {
       ) : (
         <div className="w-[90%] grid grid-cols-2 gap-4 mx-6 mt-2 md:grid-cols-2 lg:grid-cols-2">
           {data?.pages.map((page, pageIndex) =>
-            page.items.map((event: EventListProps, eventIndex) => {
-              const isLastElement = pageIndex === data.pages.length - 1 && eventIndex === page.items.length - 1;
-              return (
-                <div
-                  key={event.id}
-                  ref={isLastElement ? lastEventCardRef : null}
-                  onClick={() => navigate(`/event-details/${event.id}`)}
-                >
-                  <EventCard
-                    id={event.id}
-                    img={event.bannerImageUrl}
-                    eventTitle={event.title}
-                    eventDate={event.startDate}
-                    location={event.address}
-                    host={event.hostChannelName}
-                    hashtags={event.hashtags}
-                    dDay={event.remainDays}
-                  />
-                </div>
-              );
-            })
+            page.items
+              .filter(event => {
+                const today = new Date();
+                today.setHours(0, 0, 0, 0);
+
+                const endDate = new Date((event as EventListProps).endDate ?? event.startDate);
+
+                return endDate >= today;
+              })
+              .map((event: EventListProps, eventIndex) => {
+                const isLastElement = pageIndex === data.pages.length - 1 && eventIndex === page.items.length - 1;
+                return (
+                  <div
+                    key={event.id}
+                    ref={isLastElement ? lastEventCardRef : null}
+                    onClick={() => navigate(`/event-details/${event.id}`)}
+                  >
+                    <EventCard
+                      id={event.id}
+                      img={event.bannerImageUrl}
+                      eventTitle={event.title}
+                      eventDate={event.startDate}
+                      location={event.address}
+                      host={event.hostChannelName}
+                      hashtags={event.hashtags}
+                      dDay={event.remainDays}
+                    />
+                  </div>
+                );
+              })
           )}
         </div>
       )}

--- a/src/features/event/ui/EventList.tsx
+++ b/src/features/event/ui/EventList.tsx
@@ -3,7 +3,6 @@ import { useInfiniteScroll } from '../../../shared/hooks/useInfiniteScroll';
 import { getAllEventsInfinite, getCategoryEventsInfinite } from '../../../entities/event/api/event';
 import EventCard from '../../../shared/ui/EventCard';
 import { BaseEvent, CategoryType, TagType } from '../../../shared/types/baseEventType';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useNavigate } from 'react-router-dom';
 
 interface EventListProps extends BaseEvent {

--- a/src/features/event/ui/EventList.tsx
+++ b/src/features/event/ui/EventList.tsx
@@ -3,6 +3,8 @@ import { useInfiniteScroll } from '../../../shared/hooks/useInfiniteScroll';
 import { getAllEventsInfinite, getCategoryEventsInfinite } from '../../../entities/event/api/event';
 import EventCard from '../../../shared/ui/EventCard';
 import { BaseEvent, CategoryType, TagType } from '../../../shared/types/baseEventType';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useNavigate } from 'react-router-dom';
 
 interface EventListProps extends BaseEvent {
   id: number;
@@ -16,6 +18,8 @@ interface EventListComponentProps {
 }
 
 const EventList = ({ category, tag }: EventListComponentProps) => {
+  const navigate = useNavigate();
+
   const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteScroll<EventListProps>({
     queryKey: ['events', 'infinite', category ?? '', tag ?? ''],
     queryFn: params => {
@@ -66,7 +70,11 @@ const EventList = ({ category, tag }: EventListComponentProps) => {
             page.items.map((event: EventListProps, eventIndex) => {
               const isLastElement = pageIndex === data.pages.length - 1 && eventIndex === page.items.length - 1;
               return (
-                <div key={event.id} ref={isLastElement ? lastEventCardRef : null}>
+                <div
+                  key={event.id}
+                  ref={isLastElement ? lastEventCardRef : null}
+                  onClick={() => navigate(`/event-details/${event.id}`)}
+                >
                   <EventCard
                     id={event.id}
                     img={event.bannerImageUrl}

--- a/src/features/home/ui/EventSliderSection.tsx
+++ b/src/features/home/ui/EventSliderSection.tsx
@@ -16,8 +16,6 @@ const EventSliderSection = ({ title, events }: EventSliderSectionProps) => {
   const maxCardsToShow = 2;
   const navigate = useNavigate();
 
-  console.log(events);
-
   type SetStartIndex = Dispatch<SetStateAction<number>>;
 
   const handleNext = (setStartIndex: SetStartIndex, currentIndex: number, eventsLength: number): void => {
@@ -28,21 +26,31 @@ const EventSliderSection = ({ title, events }: EventSliderSectionProps) => {
     setStartIndex((currentIndex - 1 + eventsLength) % eventsLength);
   };
 
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+
+  const filteredEvents = events.filter(event => {
+    const endDate = new Date(event.endDate);
+    endDate.setHours(0, 0, 0, 0);
+    return endDate >= now;
+  });
+
   const eventsToShow =
-    events.length > 0
-      ? events
+    filteredEvents.length > 0
+      ? filteredEvents
           .slice(startIndex, startIndex + maxCardsToShow)
           .concat(
-            startIndex + maxCardsToShow > events.length
-              ? events.slice(0, (startIndex + maxCardsToShow) % events.length)
+            startIndex + maxCardsToShow > filteredEvents.length
+              ? filteredEvents.slice(0, (startIndex + maxCardsToShow) % filteredEvents.length)
               : []
           )
       : [];
+
   return (
     <div className="relative w-full px-6">
       <h2 className="sm:mb-3 md:mb-3.5 lg:mb-4 font-bold sm:text-sm md:text-base lg:text-lg">{title}</h2>
       <div className="flex gap-4">
-        {events.length === 0 ? (
+        {filteredEvents.length === 0 ? (
           <div className="w-full text-center text-gray-500">표시할 이벤트가 없습니다.</div>
         ) : (
           eventsToShow.map((event: EventItem) => (

--- a/src/features/home/ui/EventSliderSection.tsx
+++ b/src/features/home/ui/EventSliderSection.tsx
@@ -70,6 +70,22 @@ const EventSliderSection = ({ title, events }: EventSliderSectionProps) => {
             </div>
           ))
         )}
+        {eventsToShow.length === 1 && (
+          <div className="w-full h-full min-h-[200px] max-w-sm opacity-0" aria-hidden="true">
+            {/* 빈 카드로 자리 유지 */}
+            <EventCard
+              id={-1}
+              img=""
+              eventTitle=""
+              dDay=""
+              host=""
+              eventDate=""
+              location=""
+              hashtags={[]}
+              onClick={() => {}}
+            />
+          </div>
+        )}
       </div>
       {startIndex !== 0 && (
         <IconButton

--- a/src/features/join/api/user.ts
+++ b/src/features/join/api/user.ts
@@ -2,15 +2,11 @@ import { axiosClient } from '../../../shared/types/api/http-client';
 import { UserInfoRequest, UserInfoResponse } from '../model/userInformation';
 
 export const readUser = async (): Promise<UserInfoResponse> => {
-  const response = await axiosClient.get<{ result: UserInfoResponse }>('/users', {
-    headers: { skipAuth: true },
-  });
+  const response = await axiosClient.get<{ result: UserInfoResponse }>('/users');
   return response.data.result;
 };
 
 export const updateUser = async (data: UserInfoRequest): Promise<UserInfoResponse> => {
-  const response = await axiosClient.put<UserInfoResponse>('/users', data, {
-    headers: { skipAuth: true },
-  });
+  const response = await axiosClient.put<UserInfoResponse>('/users', data);
   return response.data;
 };

--- a/src/features/join/api/user.ts
+++ b/src/features/join/api/user.ts
@@ -2,11 +2,15 @@ import { axiosClient } from '../../../shared/types/api/http-client';
 import { UserInfoRequest, UserInfoResponse } from '../model/userInformation';
 
 export const readUser = async (): Promise<UserInfoResponse> => {
-  const response = await axiosClient.get<{ result: UserInfoResponse }>('/users');
+  const response = await axiosClient.get<{ result: UserInfoResponse }>('/users', {
+    headers: { isPublicApi: true },
+  });
   return response.data.result;
 };
 
 export const updateUser = async (data: UserInfoRequest): Promise<UserInfoResponse> => {
-  const response = await axiosClient.put<UserInfoResponse>('/users', data);
+  const response = await axiosClient.put<UserInfoResponse>('/users', data, {
+    headers: { isPublicApi: true },
+  });
   return response.data;
 };

--- a/src/features/ticket/hooks/useTicketOptionDnD.ts
+++ b/src/features/ticket/hooks/useTicketOptionDnD.ts
@@ -1,9 +1,14 @@
 import { DropResult } from '@hello-pangea/dnd';
-import { useAttachTicketOptionMutation, useDetachTicketOptionMutation } from './useTicketOptionHook';
+import {
+  useAttachTicketOptionMutation,
+  useDeleteTicketOptionMutation,
+  useDetachTicketOptionMutation,
+} from './useTicketOptionHook';
 
 export const useTicketOptionDnD = () => {
   const { mutate: attachOption } = useAttachTicketOptionMutation();
   const { mutate: detachOption } = useDetachTicketOptionMutation();
+  const { mutate: deleteOption } = useDeleteTicketOptionMutation();
 
   const onDragEnd = (result: DropResult) => {
     const { source, destination } = result;
@@ -24,13 +29,10 @@ export const useTicketOptionDnD = () => {
     if (source.droppableId === 'options' && destination.droppableId.startsWith('ticket-')) {
       const ticketId = parseInt(destination.droppableId.replace('ticket-', ''), 10);
       const ticketOptionId = parseInt(result.draggableId, 10);
-      
-      if (isNaN(ticketId) || isNaN(ticketOptionId)) {
-        console.error('Invalid ID parsing:', { ticketId, ticketOptionId });
-        return;
-      }
 
-      attachOption({ ticketId, ticketOptionId });
+      if (isNaN(ticketId) || isNaN(ticketOptionId)) {
+        attachOption({ ticketId, ticketOptionId });
+      }
       return;
     }
 
@@ -40,12 +42,20 @@ export const useTicketOptionDnD = () => {
       const ticketOptionIdStr = result.draggableId.split('-').pop();
       const ticketOptionId = ticketOptionIdStr ? parseInt(ticketOptionIdStr, 10) : undefined;
 
-      if (ticketId && ticketOptionId != undefined) {
+      if (ticketId && ticketOptionId !== undefined) {
         detachOption({ ticketId, ticketOptionId });
       }
       return;
     }
-  };
 
+    // 옵션 영역에서 자체 옵션 삭제 (모든 티켓에서 제거)
+    if (source.droppableId === 'options' && destination.droppableId === 'delete') {
+      const ticketOptionId = parseInt(result.draggableId, 10);
+      if (!isNaN(ticketOptionId)) {
+        deleteOption(ticketOptionId);
+      }
+      return;
+    }
+  };
   return { onDragEnd };
 };

--- a/src/features/ticket/hooks/useTicketOptionHook.ts
+++ b/src/features/ticket/hooks/useTicketOptionHook.ts
@@ -126,8 +126,14 @@ export const useDeleteTicketOptionMutation = () => {
       queryClient.invalidateQueries({ queryKey: ['ticketOptionDetail', ticketOptionId] });
       queryClient.invalidateQueries({ queryKey: ['attachedTicketOptions'] });
     },
-    onError: () => {
-      alert('티켓 옵션 삭제에 실패했습니다. 다시 시도해주세요.');
+    onError: error => {
+      const errorCode = error.message;
+
+      if (errorCode === '이미 응답된 티켓 옵션입니다.') {
+        alert('한 명 이상의 유저가 응답한 옵션은 삭제할 수 없습니다.');
+      } else {
+        alert('티켓 옵션 삭제에 실패했습니다. 다시 시도해주세요.');
+      }
     },
   });
 };

--- a/src/features/ticket/hooks/useTicketOptionHook.ts
+++ b/src/features/ticket/hooks/useTicketOptionHook.ts
@@ -25,7 +25,6 @@ import {
   detachTicketOption,
 } from '../api/ticketOption';
 
-
 // 티켓 옵션 조회
 export const useTicketOptions = (ticketId: number) => {
   return useQuery<{ isSuccess: boolean; result: TicketOptionResponse[] }>({
@@ -76,7 +75,7 @@ export const usePersonalTicketOptionAnswers = (ticketId: number | null) => {
   });
 };
 
-// 티켓 옵션 생성 훅 
+// 티켓 옵션 생성 훅
 export const useCreateTicketOptionMutation = () => {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -125,7 +124,7 @@ export const useDeleteTicketOptionMutation = () => {
       // 티켓 옵션 목록과 상세 정보 쿼리 리패칭
       queryClient.invalidateQueries({ queryKey: ['ticketOptions', id] });
       queryClient.invalidateQueries({ queryKey: ['ticketOptionDetail', ticketOptionId] });
-      console.log('티켓 옵션이 성공적으로 삭제되었습니다.');
+      queryClient.invalidateQueries({ queryKey: ['attachedTicketOptions'] });
     },
     onError: () => {
       alert('티켓 옵션 삭제에 실패했습니다. 다시 시도해주세요.');

--- a/src/pages/dashboard/ui/EventInfoPage.tsx
+++ b/src/pages/dashboard/ui/EventInfoPage.tsx
@@ -3,7 +3,6 @@ import ChoiceChip from '../../../../design-system/ui/ChoiceChip';
 import DefaultTextField from '../../../../design-system/ui/textFields/DefaultTextField';
 import EventDatePicker from '../../../features/event/ui/DatePicker';
 import DashboardLayout from '../../../shared/ui/backgrounds/DashboardLayout';
-import { useNavigate } from 'react-router-dom';
 import Button from '../../../../design-system/ui/Button';
 import { useUpdateEventHook } from '../../../features/dashboard/hook/useEventHook';
 import { OnlineType } from '../../../shared/types/baseEventType';
@@ -11,9 +10,10 @@ import { AddressSearch } from '../../../shared/ui/AddressSearch';
 import KakaoMap from '../../../shared/ui/KakaoMap';
 import { UpdateEventRequest } from '../../../features/dashboard/model/event';
 import { useEventDetail } from '../../../entities/event/hook/useEventHook';
+import { useQueryClient } from '@tanstack/react-query';
 
 const EventInfoPage = () => {
-  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [selectedOption, setSelectedOption] = useState('');
   const { data } = useEventDetail();
   const { mutate } = useUpdateEventHook();
@@ -60,7 +60,7 @@ const EventInfoPage = () => {
     mutate(requestData, {
       onSuccess: () => {
         alert('이벤트 정보가 저장되었습니다.');
-        navigate(`/dashboard/${data?.result.id}`);
+        queryClient.invalidateQueries({ queryKey: ['eventDetail', data.result.id] });
       },
       onError: error => {
         console.error('Error details:', error);

--- a/src/pages/event/ui/EventDetailsPage.tsx
+++ b/src/pages/event/ui/EventDetailsPage.tsx
@@ -18,11 +18,13 @@ import KakaoMap from '../../../shared/ui/KakaoMap';
 import { useCreateBookmark, useDeleteBookmark } from '../../../features/bookmark/hook/useBookmarkHook';
 import { formatDate, formatTime } from '../../../shared/lib/date';
 import { useEventDetail } from '../../../entities/event/hook/useEventHook';
+import useAuthStore from '../../../app/provider/authStore';
 
 const EventDetailsPage = () => {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const isLoggedIn = useAuthStore(state => state.isLoggedIn);
   const { data: event } = useEventDetail();
 
   const handleShareClick = (title: string) => {
@@ -81,10 +83,12 @@ const EventDetailsPage = () => {
                     iconPath={<img src={share} alt="공유하기 버튼" />}
                     onClick={() => handleShareClick(event.result.title)}
                   />
-                  <IconButton
-                    iconPath={<img src={event.result.bookmarked ? liked : like} alt="좋아요 버튼" />}
-                    onClick={handleLikeClick}
-                  />
+                  {isLoggedIn && (
+                    <IconButton
+                      iconPath={<img src={event.result.bookmarked ? liked : like} alt="좋아요 버튼" />}
+                      onClick={handleLikeClick}
+                    />
+                  )}
                 </div>
               </div>
               <div className="flex gap-2">

--- a/src/pages/event/ui/EventDetailsPage.tsx
+++ b/src/pages/event/ui/EventDetailsPage.tsx
@@ -8,7 +8,7 @@ import share from '../../../../public/assets/event-manage/details/Share.svg';
 import like from '../../../../public/assets/event-manage/details/Like.svg';
 import liked from '../../../../public/assets/event-manage/details/ClickedLike.svg';
 import TicketInfo from '../../../widgets/event/ui/TicketInfo';
-import link from '../../../../public/assets/event-manage/details/Link.svg';
+import linkIcon from '../../../../public/assets/event-manage/details/Link.svg';
 import ShareEventModal from '../../../features/event/ui/ShareEventModal';
 import participantsImg from '../../../../public/assets/event-manage/details/People.svg';
 import dateImg from '../../../../public/assets/event-manage/details/Date.svg';
@@ -135,8 +135,15 @@ const EventDetailsPage = () => {
             <div className="flex flex-col gap-2">
               <h2 className="font-bold text-xl">관련 링크</h2>
               <div className="flex items-center gap-3 mb-4">
-                <img src={link} alt="링크 이모지" />
-                <span>공식 웹사이트</span>
+                {event.result.referenceLinks.map((link: { title: string; url: string }, index: number) => (
+                  <div key={index} className="flex items-center gap-2 mb-3">
+                    <img src={linkIcon} alt="링크 이모지" />
+                    <span>{link.title}</span>
+                    <a href={link.url} target="_blank" rel="noopener noreferrer" className="text-blue-500 underline">
+                      {link.url}
+                    </a>
+                  </div>
+                ))}
               </div>
             </div>
           </div>

--- a/src/pages/event/ui/EventDetailsPage.tsx
+++ b/src/pages/event/ui/EventDetailsPage.tsx
@@ -63,7 +63,9 @@ const EventDetailsPage = () => {
         leftButtonClick={() => navigate(-1)}
         leftButtonLabel="<"
         centerContent="같이가요"
-        rightContent={<img src={Search} alt="검색" className="w-4" />}
+        rightContent={
+          <img src={Search} alt="검색" className="w-5 cursor-pointer z-30" onClick={() => navigate('/search')} />
+        }
       />
       {event ? (
         <>

--- a/src/pages/event/ui/EventDetailsPage.tsx
+++ b/src/pages/event/ui/EventDetailsPage.tsx
@@ -107,7 +107,9 @@ const EventDetailsPage = () => {
               </div>
               <div className="flex gap-2">
                 <img src={locationImg} alt="위치 이미지" />
-                <span className="text-sm md:text-base">{event.result.address}</span>
+                <span className="text-sm md:text-base">
+                  {event.result.address} {event.result.detailAddress}
+                </span>
               </div>
               <div
                 className="text-sm md:text-base py-3"

--- a/src/pages/event/ui/EventDetailsPage.tsx
+++ b/src/pages/event/ui/EventDetailsPage.tsx
@@ -105,12 +105,14 @@ const EventDetailsPage = () => {
                   {formatTime(event.result.startDate)} ~ {formatTime(event.result.endDate)}
                 </span>
               </div>
-              <div className="flex gap-2">
-                <img src={locationImg} alt="위치 이미지" />
-                <span className="text-sm md:text-base">
-                  {event.result.address} {event.result.detailAddress}
-                </span>
-              </div>
+              {event.result.address && (
+                <div className="flex gap-2">
+                  <img src={locationImg} alt="위치 이미지" />
+                  <span className="text-sm md:text-base">
+                    {event.result.address} {event.result.detailAddress}
+                  </span>
+                </div>
+              )}
               <div
                 className="text-sm md:text-base py-3"
                 dangerouslySetInnerHTML={{ __html: event.result.description }}

--- a/src/pages/menu/ui/MenuPage.tsx
+++ b/src/pages/menu/ui/MenuPage.tsx
@@ -20,7 +20,7 @@ const MenuPage = () => {
         centerContent="카테고리"
         rightContent={
           <button type="button" className="w-5 z-10" onClick={() => navigate('/search')}>
-            <img src={searchIcon} alt="Search Icon" />
+            <img src={searchIcon} alt="Search Icon" className="w-4" />
           </button>
         }
       />

--- a/src/shared/lib/formValidation.ts
+++ b/src/shared/lib/formValidation.ts
@@ -9,8 +9,10 @@ export const formSchema = z.object({
     .regex(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/, '올바른 이메일 형식이어야 합니다.'),
   phone: z
     .string()
-    .regex(/^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$/, '연락처는 -을 포함한 형식이어야 합니다.')
-    .min(1, '전화번호를 입력해주세요.'),
+    .regex(/^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$/, '연락처는 하이픈(-)을 포함한 형식이어야 합니다.')
+    .refine(val => val.length === 13, {
+      message: '연락처는 하이픈(-) 포함 13자 형식(예: 010-1234-5678)이어야 합니다.',
+    }),
 });
 export const organizerFormSchema = formSchema.pick({ email: true, phone: true });
 export const eventTitleSchema = z.object({

--- a/src/shared/types/api/http-client.ts
+++ b/src/shared/types/api/http-client.ts
@@ -14,7 +14,7 @@ export const axiosClient = axios.create({
 
 axiosClient.interceptors.request.use(
   config => {
-    if (config.headers?.skipAuth) {
+    if (config.headers?.isPublicApi) {
       return config;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이벤트 목록과 슬라이더에서 종료된 이벤트가 자동으로 제외되어, 지난 이벤트가 더 이상 표시되지 않습니다.
    - 이벤트 카드 클릭 시 상세 페이지로 이동할 수 있습니다.
    - 이벤트 상세 페이지에서 로그인한 사용자만 북마크(좋아요) 버튼을 볼 수 있습니다.
    - 이벤트 상세 페이지의 공식 웹사이트 링크가 여러 개의 참조 링크로 동적으로 표시됩니다.
    - 티켓 옵션 드래그앤드랍 기능에 옵션 삭제 기능이 추가되었습니다.

- **버그 수정**
    - 전화번호 입력 시 하이픈 포함 13자리로 정확히 입력해야 하며, 형식에 맞지 않으면 오류 메시지가 안내됩니다.
    - 티켓 옵션 삭제 시, 이미 응답이 있는 옵션은 삭제할 수 없다는 안내가 제공됩니다.

- **스타일**
    - 대시보드 및 참여자 카드, 리스트, 차트 등 UI 요소의 간격, 폰트 크기, 배경색 등 레이아웃 및 시각적 일관성이 개선되었습니다.
    - 메뉴 및 검색 아이콘의 크기가 명확하게 지정되었습니다.

- **리팩터**
    - 이벤트, 사용자 관련 API 요청 헤더를 `skipAuth`에서 `isPublicApi`로 일괄 변경해 인증 처리 방식을 일관성 있게 조정하였습니다.
    - 대시보드 응답 리스트의 렌더링 구조가 간소화되어 유지보수성이 향상되었습니다.
    - 이벤트 정보 저장 시 페이지 이동 대신 데이터 갱신이 이루어집니다.

- **기타**
    - 불필요한 콘솔 로그 및 코드 중복이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->