### PR TITLE
refactor: 메인 페이지 리팩토링

### DIFF
--- a/src/features/event/ui/EventList.tsx
+++ b/src/features/event/ui/EventList.tsx
@@ -16,6 +16,13 @@ interface EventListComponentProps {
   tag?: TagType;
 }
 
+const categoryToKorean: Record<CategoryType, string> = {
+  DEVELOPMENT_STUDY: '개발 스터디',
+  NETWORKING: '네트워킹',
+  HACKATHON: '해커톤',
+  CONFERENCE: '컨퍼런스',
+};
+
 const EventList = ({ category, tag }: EventListComponentProps) => {
   const navigate = useNavigate();
 
@@ -58,9 +65,9 @@ const EventList = ({ category, tag }: EventListComponentProps) => {
       {data?.pages[0]?.items.length === 0 ? (
         <div className="sm:text-12 md:text-14 lg:text-16 py-8 text-placeholderText ">
           {tag ? (
-            <div>생성된 이벤트가 없습니다.</div>
+            <div>열린 이벤트가 없습니다.</div>
           ) : category ? (
-            <div>생성된 {category} 이벤트가 없습니다.</div>
+            <div>열린 {categoryToKorean[category]} 이벤트가 없습니다.</div>
           ) : null}
         </div>
       ) : (

--- a/src/pages/home/ui/MainPage.tsx
+++ b/src/pages/home/ui/MainPage.tsx
@@ -26,11 +26,6 @@ const MainPage = () => {
     link: `/event-details/${event.id}`,
   }));
 
-  const handleRefresh = () => {
-    navigate('/');
-    window.location.reload();
-  };
-
   return (
     <div className="flex flex-col items-center pb-24">
       <Header
@@ -43,7 +38,7 @@ const MainPage = () => {
           />
         }
         leftButtonClassName="sm:text-lg md:text-xl lg:text-2xl font-extrabold font-nexon"
-        leftButtonClick={handleRefresh}
+        leftButtonClick={() => {}}
         leftButtonLabel="같이가요"
         rightContent={
           isLoggedIn ? (

--- a/src/pages/home/ui/MainPage.tsx
+++ b/src/pages/home/ui/MainPage.tsx
@@ -27,8 +27,11 @@ const MainPage = () => {
   }));
 
   const handleRefresh = () => {
-    navigate('/');
-    window.location.reload();
+    if (location.pathname === '/') {
+      window.location.reload();
+    } else {
+      navigate('/');
+    }
   };
 
   return (

--- a/src/pages/home/ui/MainPage.tsx
+++ b/src/pages/home/ui/MainPage.tsx
@@ -26,6 +26,11 @@ const MainPage = () => {
     link: `/event-details/${event.id}`,
   }));
 
+  const handleRefresh = () => {
+    navigate('/');
+    window.location.reload();
+  };
+
   return (
     <div className="flex flex-col items-center pb-24">
       <Header
@@ -38,7 +43,7 @@ const MainPage = () => {
           />
         }
         leftButtonClassName="sm:text-lg md:text-xl lg:text-2xl font-extrabold font-nexon"
-        leftButtonClick={() => {}}
+        leftButtonClick={handleRefresh}
         leftButtonLabel="같이가요"
         rightContent={
           isLoggedIn ? (

--- a/src/pages/menu/ui/MenuPage.tsx
+++ b/src/pages/menu/ui/MenuPage.tsx
@@ -1,8 +1,6 @@
 import { flexColumn } from '../../../../design-system/styles/flex';
 import HorizontalCardButton from '../../../../design-system/ui/buttons/HorizontalCardButton';
 import { useNavigate } from 'react-router-dom';
-
-import searchIcon from '../../../../design-system/icons/Search.svg';
 import Header from '../../../../design-system/ui/Header';
 import { buttonData } from '../../../shared/types/menuType';
 import BottomBar from '../../../widgets/main/ui/BottomBar';
@@ -17,12 +15,7 @@ const MenuPage = () => {
   return (
     <>
       <Header
-        centerContent="카테고리"
-        rightContent={
-          <button type="button" className="w-5 z-10" onClick={() => navigate('/search')}>
-            <img src={searchIcon} alt="Search Icon" className="w-4" />
-          </button>
-        }
+        centerContent="메뉴"
       />
       <div className={`${flexColumn} gap-4 px-8 md:px-10 mt-8`}>
         {buttonData.map((button, index) => (

--- a/src/pages/menu/ui/MenuPage.tsx
+++ b/src/pages/menu/ui/MenuPage.tsx
@@ -2,7 +2,7 @@ import { flexColumn } from '../../../../design-system/styles/flex';
 import HorizontalCardButton from '../../../../design-system/ui/buttons/HorizontalCardButton';
 import { useNavigate } from 'react-router-dom';
 import Header from '../../../../design-system/ui/Header';
-import { buttonData } from '../../../shared/types/menuType';
+import { getButtonData } from '../../../shared/types/menuType';
 import BottomBar from '../../../widgets/main/ui/BottomBar';
 
 const handleIconClick = (navigate: (path: string) => void, path: string) => {
@@ -11,12 +11,11 @@ const handleIconClick = (navigate: (path: string) => void, path: string) => {
 
 const MenuPage = () => {
   const navigate = useNavigate();
+  const buttonData = getButtonData();
 
   return (
     <>
-      <Header
-        centerContent="메뉴"
-      />
+      <Header centerContent="메뉴" />
       <div className={`${flexColumn} gap-4 px-8 md:px-10 mt-8`}>
         {buttonData.map((button, index) => (
           <div key={button.label}>

--- a/src/shared/types/menuType.ts
+++ b/src/shared/types/menuType.ts
@@ -8,6 +8,7 @@ import SelectedEvent from '../../..//design-system/icons/SelectedEvent.svg';
 import SelectedHost from '../../../public/assets/menu/SelectedHost.svg';
 import SelectedLogout from '../../../public/assets/menu/SelectedLogout.svg';
 import SelectedSetting from '../../../public/assets/menu/SelectedSetting.svg';
+import useAuthStore from '../../app/provider/authStore';
 
 export interface buttonData {
   iconPath: string; // 아이콘 경로
@@ -16,10 +17,22 @@ export interface buttonData {
   path: string; // 경로
 }
 
-export const buttonData: buttonData[] = [
-  { iconPath: Ticket, hoverIconPath: SelectedTicket, label: '구입한 티켓', path: '/menu/myTicket' },
-  { iconPath: Host, hoverIconPath: SelectedHost, label: '내 호스트', path: '/menu/myHost' },
-  { iconPath: Event, hoverIconPath: SelectedEvent, label: '이벤트 주최하기', path: '/event-creation' },
-  { iconPath: Setting, hoverIconPath: SelectedSetting, label: '마이페이지', path: '/menu/myPage' },
-  { iconPath: Logout, hoverIconPath: SelectedLogout, label: '로그아웃', path: '/menu/logout' },
-];
+export const getButtonData = (): buttonData[] => {
+  const isLoggedIn = useAuthStore.getState().isLoggedIn;
+
+  const baseButtons: buttonData[] = [
+    { iconPath: Ticket, hoverIconPath: SelectedTicket, label: '구입한 티켓', path: '/menu/myTicket' },
+    { iconPath: Host, hoverIconPath: SelectedHost, label: '내 호스트', path: '/menu/myHost' },
+    { iconPath: Event, hoverIconPath: SelectedEvent, label: '이벤트 주최하기', path: '/event-creation' },
+    { iconPath: Setting, hoverIconPath: SelectedSetting, label: '마이페이지', path: '/menu/myPage' },
+  ];
+
+  if (isLoggedIn) {
+    return [
+      ...baseButtons,
+      { iconPath: Logout, hoverIconPath: SelectedLogout, label: '로그아웃', path: '/menu/logout' },
+    ];
+  }
+
+  return baseButtons;
+};

--- a/src/widgets/main/ui/BottomBar.tsx
+++ b/src/widgets/main/ui/BottomBar.tsx
@@ -10,11 +10,7 @@ const BottomBar = () => {
           key={index}
           className="flex flex-col justify-center items-center w-24 h-20 cursor-pointer"
           onClick={() => {
-            if (location.pathname === item.path) {
-              navigate(-1);
-            } else {
-              navigate(item.path);
-            }
+            navigate(item.path);
           }}
         >
           <img src={item.icon} alt={`${item.label}Icon`} className={`${item.iconClassName} object-contain`} />


### PR DESCRIPTION
### 같이가요 로고 클릭 시 새로고침

https://github.com/user-attachments/assets/2af6fbcc-5a13-4aad-b8ae-7c3004a15c5f

### 하단바 홈 버튼 클릭시 뒤로가기 로직 삭제

https://github.com/user-attachments/assets/6c64a262-c378-4e8c-9216-8e9b7c794ad5

### 카테고리 페이지 이벤트 정보 없을 때 한글로 보이게 수정
<img width="1920" alt="카테고리이벤트없을때" src="https://github.com/user-attachments/assets/8dbebf1a-b370-4ae0-b9f3-42103fc0098b" />

### 메뉴 관련 리팩토링

https://github.com/user-attachments/assets/4b2a1be5-78ef-4728-ac86-162852a502ea

- 로그아웃 상태일 때 로그아웃 버튼 삭제
- 카테고리 문구 → 메뉴로 수정
- 돋보기 이미지와 관련된 로직 삭제 (검색)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 메뉴 버튼 목록이 로그인 상태에 따라 동적으로 변경되어, 로그인 시 로그아웃 버튼이 표시됩니다.
    - 헤더의 왼쪽 "같이가요" 버튼 클릭 시 홈으로 이동하며 페이지가 새로고침됩니다.

- **버그 수정**
    - 이벤트 목록이 비어 있을 때 카테고리명 및 안내 메시지가 더 자연스럽고 정확한 한국어로 표시됩니다.

- **UI 개선**
    - 메뉴 페이지 헤더의 중앙 텍스트가 "카테고리"에서 "메뉴"로 변경되고, 검색 버튼이 제거되었습니다.
    - 하단 바에서 메뉴 클릭 시 항상 해당 경로로 이동하도록 동작이 단순화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->