### PR TITLE
refactor: 이벤트 카드/상세 리팩토링

### DIFF
--- a/src/features/home/ui/EventSliderSection.tsx
+++ b/src/features/home/ui/EventSliderSection.tsx
@@ -63,7 +63,7 @@ const EventSliderSection = ({ title, events }: EventSliderSectionProps) => {
                 dDay={event.remainDays}
                 host={event.hostChannelName}
                 eventDate={event.startDate}
-                location={event.onlineType}
+                location={event.address}
                 hashtags={event.hashtags}
                 onClick={() => navigate(`/event-details/${event.id}`)}
               />

--- a/src/features/home/ui/EventSliderSection.tsx
+++ b/src/features/home/ui/EventSliderSection.tsx
@@ -54,7 +54,7 @@ const EventSliderSection = ({ title, events }: EventSliderSectionProps) => {
           <div className="w-full text-center text-gray-500">표시할 이벤트가 없습니다.</div>
         ) : (
           eventsToShow.map((event: EventItem) => (
-            <div key={event.id} className="w-full h-full min-h-[200px] max-w-sm">
+            <div key={event.id} className="w-full h-full min-h-[200px] max-w-sm min-w-[200px]">
               <EventCard
                 key={event.id}
                 id={event.id}

--- a/src/pages/event/ui/EventDetailsPage.tsx
+++ b/src/pages/event/ui/EventDetailsPage.tsx
@@ -142,14 +142,13 @@ const EventDetailsPage = () => {
                 {event.result.referenceLinks.map((link: { title: string; url: string }, index: number) => (
                   <div key={index} className="flex items-center gap-2">
                     <img src={linkIcon} alt="링크 이모지" />
-                    <span>{link.title}</span>
                     <a
                       href={link.url}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-blue-500 underline"
                     >
-                      {link.url}
+                      {link.title}
                     </a>
                   </div>
                 ))}

--- a/src/shared/ui/EventCard.tsx
+++ b/src/shared/ui/EventCard.tsx
@@ -59,7 +59,7 @@ const EventCard = ({
       {/* 상세 정보 */}
       <div className="flex flex-col gap-1 mt-4">
         <div className="flex justify-between">
-          <h2 className="text-sm font-semibold line-clamp-2 overflow-hidden">{eventTitle}</h2>
+          <h2 className="max-w-[130px] text-sm font-semibold truncate overflow-hidden">{eventTitle}</h2>
           {dDay !== 'false' && (
             <div className="sm:max-w-10 md:max-w-15">
               <Countdown isChecked>{dDay}</Countdown>

--- a/src/shared/ui/EventCard.tsx
+++ b/src/shared/ui/EventCard.tsx
@@ -76,7 +76,7 @@ const EventCard = ({
 
         <div className="flex items-center text-xs text-gray-500">
           <img src={locationImg} alt="위치" className="w-3 h-3 mr-1" />
-          <div className="line-clamp-2 overflow-hidden">{location}</div>
+          <div className="w-full truncate overflow-hidden">{location}</div>
         </div>
 
         {/* 승인 여부 표시 */}

--- a/src/widgets/event/ui/TicketInfo.tsx
+++ b/src/widgets/event/ui/TicketInfo.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTickets } from '../../../features/ticket/hooks/useTicketHook';
 import { useOrderTicket } from '../../../features/ticket/hooks/useOrderHook';
 import { readTicketOptions } from '../../../features/ticket/api/ticketOption';
+import useAuthStore from '../../../app/provider/authStore';
 
 const TicketInfo = ({ eventId }: { eventId: number }) => {
   const limitNum = 4;
@@ -12,6 +13,7 @@ const TicketInfo = ({ eventId }: { eventId: number }) => {
   const [quantity, setQuantity] = useState<{ [key: number]: number }>({});
   const navigate = useNavigate();
   const { mutate: orderTickets } = useOrderTicket();
+  const isLoggedIn = useAuthStore(state => state.isLoggedIn);
 
   useEffect(() => {
     if (data && data.isSuccess) {
@@ -37,15 +39,11 @@ const TicketInfo = ({ eventId }: { eventId: number }) => {
     }));
   };
 
-  // 바로 결제 
-  const handleDirectOrder = (
-    ticketId: number,
-    eventId: number,
-    ticketCnt: number
-  ) => {
+  // 바로 결제
+  const handleDirectOrder = (ticketId: number, eventId: number, ticketCnt: number) => {
     const ticketInfo = { ticketId, eventId, ticketCnt };
     orderTickets(ticketInfo, {
-      onSuccess: (response) => {
+      onSuccess: response => {
         if (response.isSuccess && Array.isArray(response.result)) {
           const orderIds = response.result;
           navigate('/payment/ticket-confirm', {
@@ -60,6 +58,11 @@ const TicketInfo = ({ eventId }: { eventId: number }) => {
 
   // 티켓 옵션 응답 페이지 이동.
   const orderTicket = async (ticketId: number, eventId: number, ticketCnt: number) => {
+    if (!isLoggedIn) {
+      alert('로그인이 필요한 서비스입니다.');
+      return;
+    }
+
     try {
       const res = await readTicketOptions(ticketId);
       if (res.isSuccess && res.result.length > 0) {
@@ -74,7 +77,7 @@ const TicketInfo = ({ eventId }: { eventId: number }) => {
     }
   };
   if (isLoading) return <div>Loading...</div>;
-  if (isError || !data || !data.isSuccess) return <div>티켓 정보를 불러올 수 없습니다.</div>;
+  if (isError || !data || !data.isSuccess) return <div>로그인이 필요한 서비스입니다.</div>;
 
   return (
     <div className="w-full h-full">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ import autoprefixer from 'autoprefixer';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd());
 
-  const API_BASE_URL = `${env.VITE_API_BASE_URL ?? 'http://api.gotogether.io.kr:8080'}`;
+  const API_BASE_URL = `${env.VITE_API_BASE_URL ?? 'http://api.gotogether.io.kr:8081'}`;
 
   return {
     plugins: [react()],


### PR DESCRIPTION
### 이벤트 카드 제목 말줄임표 처리 및 이미지 크기 오류 해결
https://github.com/user-attachments/assets/a18174be-07e4-4005-859d-7b165f7f2738

### 이벤트 카드 주소 말줄임표 처리
<img width="400" alt="이벤트주소말줄임표" src="https://github.com/user-attachments/assets/c3ebd29e-4a95-41b7-bc74-bf08a012563b" />

### 이벤트 상세 미로그인 시 alert 및 메시지 수정
<img width="400" alt="로그인이필요한서비스1" src="https://github.com/user-attachments/assets/69a99d16-ff45-432c-ad42-7aaf193ddef1" />
<img width="400" alt="로그인이필요한서비스2" src="https://github.com/user-attachments/assets/6bd984e9-007a-4cef-b516-84f80861a295" />


### 이벤트 상세 링크 첨부 URL을 제목에 하이퍼링크로 수정
<img width="400" alt="title을 url하이퍼링크로 만들기" src="https://github.com/user-attachments/assets/0f15fb6a-1a59-48a3-a245-78bbf6eca0fa" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - 이벤트 카드의 위치 정보가 온라인 유형에서 실제 주소로 변경되어 보다 정확한 위치가 표시됩니다.
    - 이벤트 카드와 위치 텍스트가 한 줄로 잘려 보이도록 스타일이 개선되었습니다.

- **기능 개선**
    - 이벤트 상세 페이지에서 참고 링크의 제목이 직접적으로 표시되어 가독성이 향상되었습니다.
    - 티켓 정보에서 비로그인 사용자가 주문 시 로그인 필요 알림이 표시되고, 티켓 정보 로딩 실패 시에도 로그인 필요 메시지가 안내됩니다.

- **환경 설정**
    - API 기본 포트가 8080에서 8081로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->