### PR TITLE
fix: 구매/참여자 카드 api 호출 hook 함수 오타 수정

### DIFF
--- a/src/features/dashboard/ui/ParticipantCard.tsx
+++ b/src/features/dashboard/ui/ParticipantCard.tsx
@@ -13,8 +13,7 @@ interface ParticipantCardProps {
 }
 
 const ParticipantCard = ({ participant, onCheckClick }: ParticipantCardProps) => {
-  const { mutate: approveParticipant } = useApproveParticipants(participant.orderId);
-
+  const { mutate: approveParticipant } = useApproveParticipants(participant.id);
   // useQuery를 사용한 에러 핸들링
   const { error } = usePersonalTicketOptionAnswers(participant.ticketId);
 


### PR DESCRIPTION
- 구매/참여자 관리 페이지 내부 인증된 참여자 api 호출 hook 함수 오타 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 참가자 승인 시 잘못된 식별자가 사용되던 문제를 해결하여, 이제 올바른 참가자 ID로 승인 처리가 이루어집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->