### PR TITLE
chore: mkcert 기반 SSL 인증서 자동 생성 스크립트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 *storybook.log
 .env
+
+# mkcert local certificates
+*_wildcard*.pem

--- a/scripts/setup-cert.sh
+++ b/scripts/setup-cert.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+CERT_NAME="_wildcard.gotogether.io.kr"
+
+echo "🔐 Setting up mkcert for gotogether.io.kr..."
+
+# 1. mkcert 설치 확인
+if ! command -v mkcert &> /dev/null; then
+  echo "❌ mkcert가 설치되어 있지 않습니다. 먼저 'brew install mkcert'로 설치해주세요."
+  exit 1
+fi
+
+# 2. 로컬 CA 설치
+mkcert -install
+
+# 3. 인증서 생성 (파일이 없을 때만)
+if [[ -f "${CERT_NAME}.pem" && -f "${CERT_NAME}-key.pem" ]]; then
+  echo "✅ 인증서가 이미 존재합니다. 새로 생성하지 않습니다."
+else
+  mkcert "*.gotogether.io.kr" 127.0.0.1 ::1
+  echo "✅ 인증서 생성 완료: ${CERT_NAME}.pem, ${CERT_NAME}-key.pem"
+fi

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react-swc';
 import path from 'path';
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
+import fs from 'fs';
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
@@ -19,6 +20,10 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       host: true,
+      https: {
+        key: fs.readFileSync('_wildcard.gotogether.io.kr+2-key.pem'),
+        cert: fs.readFileSync('_wildcard.gotogether.io.kr+2.pem'),
+      },
       allowedHosts: ['gotogether.io.kr'],
       proxy: {
         '/api/v1': {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - mkcert로 생성된 로컬 인증서 파일을 Git 추적에서 제외하도록 `.gitignore`를 업데이트했습니다.
  - 로컬 TLS 인증서 생성을 자동화하는 스크립트를 추가했습니다.
  - 개발 서버가 HTTPS를 지원하도록 설정을 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->