### PR TITLE
design: 반응형 레이아웃 개선 

### DIFF
--- a/design-system/ui/ChoiceChip.tsx
+++ b/design-system/ui/ChoiceChip.tsx
@@ -27,14 +27,16 @@ const ChoiceChip = ({
   const [selected, setSelected] = useState<string>(value || options[0].value || '');
 
   useEffect(() => {
-    if (value) {
+    if (value !== undefined && value !== selected) {
       setSelected(value);
     }
   }, [value]);
 
   const handleClick = (optionValue: string) => {
-    setSelected(optionValue);
-    onSelect(optionValue);
+    if (optionValue !== selected) {
+      setSelected(optionValue);      // 내부 하이라이트
+      onSelect(optionValue);         // 부모에 알림
+    }
   };
 
   return (

--- a/design-system/ui/buttons/HorizontalCardButton.tsx
+++ b/design-system/ui/buttons/HorizontalCardButton.tsx
@@ -31,7 +31,7 @@ export default function HorizontalCardButton({
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div className={`flex items-center justify-center gap-5 ${className}`}>
+      <div className={`flex items-center justify-center gap-5 sm:gap-1 md:gap-5 ${className}`}>
         {isHovered && hoverIconPath ? hoverIconPath : iconPath}
         <p>{label}</p>
       </div>

--- a/src/entities/event/api/event.ts
+++ b/src/entities/event/api/event.ts
@@ -20,7 +20,7 @@ export const getAllEventsInfinite = async ({
 }: PaginationParams & { tag?: TagType }): Promise<{ items: EventItem[]; hasNextPage: boolean }> => {
   const params = new URLSearchParams();
 
-  if (tag) params.append('tags', tag);
+  if (tag) params.append('tag', tag);
   params.append('page', page.toString());
   params.append('size', size.toString());
 
@@ -62,7 +62,7 @@ export const getCategoryEventsInfinite = async ({
 
 // 태그별 이벤트 목록 조회 (최신, 인기, 마감 / 기본 정보)
 export const getEventByTag = async (tag: TagType, { page, size }: PaginationParams): Promise<EventItem[]> => {
-  const response = await axiosClient.get<{ result: EventItem[] }>(`/events?tags=${tag}&page=${page}&size=${size}`, {
+  const response = await axiosClient.get<{ result: EventItem[] }>(`/events?tag=${tag}&page=${page}&size=${size}`, {
     headers: { isPublicApi: true },
   });
   return response.data.result || [];

--- a/src/features/dashboard/ui/DragArea.tsx
+++ b/src/features/dashboard/ui/DragArea.tsx
@@ -53,7 +53,7 @@ const DragArea = ({ options, droppableId, ticketSurveyAddButton = false, activeB
               <div className="col-span-1 flex items-center h-[3.5rem] bg-deDayBgLight rounded">
                 <HorizontalCardButton
                   iconPath={<img src={AddButton2} alt="추가 버튼" />}
-                  className="text-sm  !justify-start [&>div]:!justify-start"
+                  className="text-sm sm:text-xs md:text-sm !justify-start [&>div]:!justify-start"
                   label="티켓 옵션 새로 생성하기"
                   onClick={() => {
                     navigate(`/dashboard/${id}/ticket/option/create`);

--- a/src/features/ticket/ui/TicketOptionFormSection.tsx
+++ b/src/features/ticket/ui/TicketOptionFormSection.tsx
@@ -39,7 +39,7 @@ export const TicketOptionFormSection = ({ form }: { form: ReturnType<typeof useT
 
       {/*응답 종류 선택란*/}
       <div>
-        <div className="w-32 md:w-56 mb-5">
+        <div className="w-32 md:w-56 sm:w-56 mb-5">
           <p className="block text-m font-semibold text-gray-700">응답을 어떤 형식으로 받을까요?</p>
           <p className="block mb-1 text-placeholderText text-11 md:text-13">한 개만 선택할 수 있습니다.</p>
           <ChoiceChip
@@ -61,7 +61,7 @@ export const TicketOptionFormSection = ({ form }: { form: ReturnType<typeof useT
 
       {/*필수 응답 토글*/}
       <div className="flex items-center justify-between mb-5">
-        <div className="w-40 md:w-60">
+        <div className="w-48 md:w-60">
           <p className="block text-sm font-semibold text-gray-700">필수로 선택하게 할까요?</p>
           <p className="text-gray-400 text-xs">이 옵션을 키면 해당 질문에 응답을 해야만 티켓을 결제 할 수 있습니다.</p>
         </div>

--- a/src/features/ticket/ui/TicketOptionListSection.tsx
+++ b/src/features/ticket/ui/TicketOptionListSection.tsx
@@ -14,7 +14,7 @@ export const TicketOptionListSection = ({ form }: { form: ReturnType<typeof useT
       <div>
         {(state.question.responseFormat === 'SINGLE' || state.question.responseFormat === 'MULTIPLE') && (
           <>
-            <p className="block text-m font-semibold text-gray-700">옵션</p>
+            <p className="block text-m font-semibold text-gray-700">선택지</p>
             <p className="text-gray-400 text-xs">선택지를 여러개 만들 수 있습니다.</p>
             {state.warnings.optionWarning && (
               <p className="text-red-500 text-xs mb-2">{state.warnings.optionWarning}</p>

--- a/src/pages/dashboard/ui/ticket/TicketCreatePage.tsx
+++ b/src/pages/dashboard/ui/ticket/TicketCreatePage.tsx
@@ -14,7 +14,6 @@ const TicketCreatePage = () => {
   const { mutate: createTicket } = useCreateTicket();
   const { id } = useParams();
   const eventId = Number(id);
-
   const [ticketData, setTicketData] = useState<CreateTicketRequest>({
     eventId: eventId,
     ticketType: 'FIRST_COME',
@@ -26,18 +25,6 @@ const TicketCreatePage = () => {
     endDate: '',
   });
 
-  const handleTicketTypeChange = (type: string) => {
-    let mappedType: string;
-    if (type === '선착순') {
-      mappedType = 'FIRST_COME';
-    } else {
-      mappedType = 'SELECTION';
-    }
-    setTicketData(prev => ({
-      ...prev,
-      ticketType: mappedType,
-    }));
-  };
 
   // 필드값 업데이트
   const handleInputChange = (field: keyof CreateTicketRequest) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -102,11 +89,21 @@ const TicketCreatePage = () => {
         <div>
           <div className="w-32 md:w-40 my-1">
             <p className="font-semibold px-1 mb-1 text-gray-700">티켓 종류</p>
-            <ChoiceChip {...TwoOptions.args} onSelect={handleTicketTypeChange} />
+            <ChoiceChip {...TwoOptions.args} value={ticketData.ticketType}          // ← 부모가 현재 값 전달
+              onSelect={(type) =>
+                setTicketData((prev) => ({ ...prev, ticketType: type }))
+              } />
           </div>
-          <p className="block px-1 mb-1 text-placeholderText text-11 md:text-13">
-            참가자가 선착순으로 발행된 티켓을 구매합니다.
-          </p>
+          {ticketData.ticketType === 'FIRST_COME' ? (
+            <p className="block px-1 mb-1 text-placeholderText text-11 md:text-13">
+              참가자가 선착순으로 발행된 티켓을 구매합니다.
+            </p>
+          ) : (
+            <p className="block px-1 mb-1 text-placeholderText text-11 md:text-13">
+              참가자가 티켓을 구매하면, 주최자가 선별하여 승인합니다.
+            </p>
+          )}
+
         </div>
         {/*티켓 이름 입력란*/}
         <div>

--- a/src/shared/hooks/useImageUpload.ts
+++ b/src/shared/hooks/useImageUpload.ts
@@ -26,8 +26,8 @@ const useImageUpload = ({
   }, [value, onSuccess, useDefaultImage, previewUrl]);
 
   const validateFile = (file: File) => {
-    if (file.size > 1000 * 1024) {
-      alert('파일 크기는 1MB를 초과할 수 없습니다.');
+    if (file.size > 4 * 1024 * 1024) {
+      alert('파일 크기는 4MB를 초과할 수 없습니다.');
       return false;
     }
     if (!['image/jpg', 'image/jpeg', 'image/png'].includes(file.type)) {

--- a/src/widgets/dashboard/ui/main/EventOverview.tsx
+++ b/src/widgets/dashboard/ui/main/EventOverview.tsx
@@ -8,8 +8,8 @@ const EventOverview = ({ eventInfo }: { eventInfo?: HostDashboardResponse }) => 
         <h2 className="text-base font-semibold mb-2">이벤트 개요</h2>
         <hr />
       </div>
-      <div className="flex items-center text-xs md:text-sm">
-        <h4 className="text-main font-semibold mr-4">
+      <div className="flex items-center text-xs md:text-sm ">
+        <h4 className="text-main font-semibold mr-4 sm:mr-2">
           <span className="block md:inline">{`온라인`}</span>
           <span className="block md:inline">{`이벤트`}</span>
         </h4>


### PR DESCRIPTION
온라인 이벤트 글씨 / 티켓 옵션 select -> 반응형
사진 업로드 용량 제한 1MB → 늘리기(3~4MB로)
주최자선별 문구 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 선택형 칩(ChoiceChip) 컴포넌트의 선택 상태 동기화 및 이벤트 처리 로직이 개선되어 불필요한 상태 업데이트와 콜백 호출이 방지됩니다.

* **스타일**
  * 버튼과 라벨 사이의 간격 및 폰트 크기가 반응형으로 조정되어 다양한 화면 크기에서 더 나은 레이아웃을 제공합니다.
  * 티켓 옵션 폼, 옵션 리스트, 이벤트 개요 등 여러 UI 컴포넌트의 레이아웃 및 텍스트 스타일이 개선되었습니다.
  * 옵션 섹션의 라벨이 "옵션"에서 "선택지"로 변경되었습니다.

* **새 기능**
  * 티켓 생성 페이지에서 티켓 유형에 따라 안내 문구가 동적으로 변경됩니다.

* **기타**
  * 이미지 업로드 시 허용 파일 용량이 1MB에서 4MB로 상향 조정되었습니다.
  * 이벤트 태그 필터 API 쿼리 파라미터가 'tags'에서 'tag'로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->