### PR TITLE
refact: 티켓 구매 제한 1장 수정

### DIFF
--- a/src/widgets/event/ui/TicketInfo.tsx
+++ b/src/widgets/event/ui/TicketInfo.tsx
@@ -9,7 +9,7 @@ import useAuthStore from '../../../app/provider/authStore';
 import clock from '../../../../public/assets/event-manage/details/Clock.svg';
 
 const TicketInfo = ({ eventId }: { eventId: number }) => {
-  const limitNum = 4;
+  const limitNum = 1;
   const { data, isError, isLoading } = useTickets(eventId);
   const [quantity, setQuantity] = useState<{ [key: number]: number }>({});
   const navigate = useNavigate();


### PR DESCRIPTION
티켓 구매 제한 1장으로 수정했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 티켓 유형별 최대 선택 가능 수량이 4장에서 1장으로 변경되었습니다. 이제 각 티켓 유형당 1장만 선택할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->