### PR TITLE
fix: 참가자 정보 조회 size 제한 에러 해결

### DIFF
--- a/src/features/dashboard/hook/useParticipants.ts
+++ b/src/features/dashboard/hook/useParticipants.ts
@@ -5,11 +5,7 @@ import { ApiResponse } from '../../../shared/types/api/apiResponse';
 import { AxiosError } from 'axios';
 import { approveParticipants } from '../../../features/dashboard/api/participants';
 
-export const useParticipants = (
-  tags: string = 'all',
-  page: number = 0,
-  size: number = 10
-) => {
+export const useParticipants = (tags: string = 'all', page: number = 0, size: number = 300) => {
   const { id } = useParams();
   const eventId = Number(id);
 
@@ -31,15 +27,13 @@ export const useParticipants = (
 };
 
 export const useApproveParticipants = (orderId: number) => {
-
   const queryClient = useQueryClient();
 
   return useMutation<ApiResponse<string>, AxiosError, { orderId: number }>({
     mutationFn: () => approveParticipants({ orderId }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        predicate: (query) =>
-          Array.isArray(query.queryKey) && query.queryKey[0] === 'participants',
+        predicate: query => Array.isArray(query.queryKey) && query.queryKey[0] === 'participants',
       });
     },
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 기본 참가자 조회 수를 10명에서 300명으로 상향 조정하여, 한 번에 더 많은 참가자 정보를 불러올 수 있도록 개선되었습니다.  
  * 일부 내부 코드가 간결하게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->