### PR TITLE
refactor: 이벤트 생성 및 수정 중 하이퍼링크 예외처리 구현

### DIFF
--- a/src/features/event/ui/LinkInput.tsx
+++ b/src/features/event/ui/LinkInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { FunnelState } from '../model/FunnelContext';
 import AddButton from '../../../../public/assets/event-manage/creation/AddBtn.svg';
 import CloseButton from '../../../../public/assets/event-manage/creation/CloseBtn.svg';
@@ -14,9 +14,10 @@ interface LinkInputProps {
   onChange?: (value: Link[]) => void;
   eventState?: FunnelState['eventState'];
   setEventState?: React.Dispatch<React.SetStateAction<FunnelState['eventState']>>;
+  onValidationChange?: (isValid: boolean) => void;
 }
 
-const LinkInput = ({ value, onChange, eventState, setEventState }: LinkInputProps) => {
+const LinkInput = ({ value, onChange, eventState, setEventState, onValidationChange }: LinkInputProps) => {
   const links = value ?? eventState?.referenceLinks ?? [];
 
   const [activeInput, setActiveInput] = useState<{ field: 'title' | 'url' | null }>({
@@ -25,6 +26,11 @@ const LinkInput = ({ value, onChange, eventState, setEventState }: LinkInputProp
   const [hoveredInput, setHoveredInput] = useState<{ field: 'title' | 'url' | null }>({
     field: null,
   });
+
+  const validateLinks = (linkArray: Link[]) => {
+    if (linkArray.length === 0) return true;
+    return linkArray.every(link => link.title.trim() !== '' && link.url.trim() !== '');
+  };
 
   const updateAll = (newLinks: Link[]) => {
     onChange?.(newLinks);
@@ -44,9 +50,20 @@ const LinkInput = ({ value, onChange, eventState, setEventState }: LinkInputProp
     updateAll(newLinks);
   };
 
+  useEffect(() => {
+    const isValid = validateLinks(links);
+    onValidationChange?.(isValid);
+  }, [links, onValidationChange]);
+
   return (
     <div className="flex flex-col gap-1">
-      <h1 className="font-bold text-black text-lg">관련 링크</h1>
+      <div className="flex flex-row gap-2 items-center">
+        <h1 className="font-bold text-black text-lg">관련 링크</h1>
+        {links.length > 0 && (<p className="text-placeholderText text-12">
+          링크 추가 시 하이퍼링크와 URL을 모두 입력해주세요
+        </p>)}
+
+      </div>
 
       {links.map((link, index) => (
         <div key={index} className="mb-2">
@@ -64,7 +81,7 @@ const LinkInput = ({ value, onChange, eventState, setEventState }: LinkInputProp
                 value={link.title}
                 onChange={e => updateLink(index, 'title', e.target.value)}
                 className="w-full min-w-[3rem] md:min-w-[6rem] h-8 text-placeholderText ml-1 outline-none bg-transparent text-sm md:text-base"
-                placeholder="참조링크"
+                placeholder="하이퍼링크"
                 autoFocus={activeInput.field === link.title && activeInput.field === 'title'}
               />
             </div>

--- a/src/pages/dashboard/ui/EventDetailPage.tsx
+++ b/src/pages/dashboard/ui/EventDetailPage.tsx
@@ -20,6 +20,7 @@ const EventDetailPage = () => {
   const [bannerImageUrl, setBannerImageUrl] = useState('');
   const [description, setDescription] = useState('');
   const [referenceLinks, setReferenceLinks] = useState<Link[]>([]);
+  const [isLinkValid, setIsLinkValid] = useState(true);
 
   const queryClient = useQueryClient();
 
@@ -67,16 +68,29 @@ const EventDetailPage = () => {
     });
   };
 
+  const handleLinkValidation = (valid: boolean) => {
+    setIsLinkValid(valid);
+  };
+
   return (
     <DashboardLayout centerContent="DASHBOARD">
       <div className="flex flex-col gap-5 mt-8 px-7">
         <h1 className="text-center text-xl font-bold mb-5">이벤트 상세 정보</h1>
         <FileUpload value={bannerImageUrl} onChange={setBannerImageUrl} useDefaultImage={false} />
         <TextEditor value={description} onChange={setDescription} />
-        <LinkInput value={referenceLinks} onChange={setReferenceLinks} />
+        <LinkInput 
+          value={referenceLinks} 
+          onChange={setReferenceLinks} 
+          onValidationChange={handleLinkValidation}
+        />
       </div>
       <div className="w-full p-7">
-        <Button label="저장하기" onClick={handleSave} className="w-full h-12 rounded-full" />
+        <Button 
+          label="저장하기" 
+          onClick={handleSave} 
+          className="w-full h-12 rounded-full" 
+          disabled={!isLinkValid}
+        />
       </div>
     </DashboardLayout>
   );

--- a/src/pages/event/ui/create-event/EventInfoPage.tsx
+++ b/src/pages/event/ui/create-event/EventInfoPage.tsx
@@ -12,7 +12,7 @@ const EventInfoPage = ({ onValidationChange }: EventInfoPageProps) => {
   const { eventState, setEventState } = useFunnelState();
   const [isFileValid, setIsFileValid] = useState(false);
   const [isTextValid, setIsTextValid] = useState(false);
-  const [isLinkValid, setIsLinkValid] = useState(false);
+  const [isLinkValid, setIsLinkValid] = useState(true);
 
   const handleFileValidation = (valid: boolean) => {
     setIsFileValid(valid);
@@ -46,7 +46,12 @@ const EventInfoPage = ({ onValidationChange }: EventInfoPageProps) => {
         setEventState={setEventState}
         onValidationChange={handleTextValidation}
       />
-      <LinkInput eventState={eventState} setEventState={setEventState} onValidationChange={handleLinkValidation} />
+      <LinkInput 
+        eventState={eventState} 
+        setEventState={setEventState} 
+        onValidationChange={handleLinkValidation} 
+        value={eventState?.referenceLinks}
+      />
     </div>
   );
 };

--- a/src/pages/event/ui/create-event/EventInfoPage.tsx
+++ b/src/pages/event/ui/create-event/EventInfoPage.tsx
@@ -12,6 +12,7 @@ const EventInfoPage = ({ onValidationChange }: EventInfoPageProps) => {
   const { eventState, setEventState } = useFunnelState();
   const [isFileValid, setIsFileValid] = useState(false);
   const [isTextValid, setIsTextValid] = useState(false);
+  const [isLinkValid, setIsLinkValid] = useState(false);
 
   const handleFileValidation = (valid: boolean) => {
     setIsFileValid(valid);
@@ -20,10 +21,15 @@ const EventInfoPage = ({ onValidationChange }: EventInfoPageProps) => {
   const handleTextValidation = (valid: boolean) => {
     setIsTextValid(valid);
   };
+
+  const handleLinkValidation = (valid: boolean) => { 
+    setIsLinkValid(valid);
+  };
+
   useEffect(() => {
-    const allValid = isFileValid && isTextValid;
+    const allValid = isFileValid && isTextValid && isLinkValid;
     onValidationChange?.(allValid);
-  }, [isFileValid, isTextValid, onValidationChange]);
+  }, [isFileValid, isTextValid, isLinkValid,onValidationChange]);
 
   return (
     <div className="w-full px-5 space-y-8">
@@ -34,13 +40,13 @@ const EventInfoPage = ({ onValidationChange }: EventInfoPageProps) => {
         useDefaultImage={false}
         onValidationChange={handleFileValidation}
       />
-      <TextEditor 
+      <TextEditor
         value={eventState?.description ?? ''}
         eventState={eventState}
         setEventState={setEventState}
         onValidationChange={handleTextValidation}
       />
-      <LinkInput eventState={eventState} setEventState={setEventState} />
+      <LinkInput eventState={eventState} setEventState={setEventState} onValidationChange={handleLinkValidation} />
     </div>
   );
 };

--- a/src/shared/ui/backgrounds/EventRegisterLayout.tsx
+++ b/src/shared/ui/backgrounds/EventRegisterLayout.tsx
@@ -48,7 +48,7 @@ const EventRegisterLayout = ({
       <div className="absolute top-0 w-full h-36 md:h-40 bg-gradient-to-br from-[#FF5593] to-[rgb(255,117,119)] rounded-b-[60px] z-10">
         <Header
           centerContent="이벤트 등록"
-          leftButtonLabel={goHome ? (              <IconButton
+          leftButtonLabel={goHome ? (<IconButton
             iconPath={<img src={HomeButton} />}
             onClick={() => navigate('/')}
             iconClassName="cursor-pointer z-30 ml-auto"


### PR DESCRIPTION
## 이벤트 생성

- 하이퍼링크 `url` 미기입으로 인한 `disabled` 처리
<img width="384" height="1754" alt="image" src="https://github.com/user-attachments/assets/0e55e48c-51ca-4834-bdfc-0448f059c968" />

- 하이퍼링크 기입을 완료하거나 추가하지 않았을 때
<img width="384" height="1754" alt="image" src="https://github.com/user-attachments/assets/9d182956-b8cf-4207-a42b-a72275ae153e" />
<img width="384" height="1754" alt="image" src="https://github.com/user-attachments/assets/024968e4-64e4-4c72-a8a9-a6ab2102c79a" />

## 이벤트 수정

- 하이퍼링크 `title` 미기입으로 인한 `disabled` 처리
<img width="384" height="1754" alt="image" src="https://github.com/user-attachments/assets/33363eb6-c795-4025-be5b-ab72a057137d" />

- 하이퍼링크 기입 완료
<img width="384" height="1754" alt="image" src="https://github.com/user-attachments/assets/7d7dcc93-97c8-44ac-ade3-0a5bce5105f0" />

---

- 관련 링크 추가 시 필수로 `title`과 `url`을 작성하도록 구현
- 관련 링크 추가 시 안내 문구 출력
- 관련 링크 추가 시 `title`과 `url` 중 하나라도 입력하지 않았을 때 `다음`과 `저장하기` 버튼을 비활성화함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 참조 링크 입력란에 유효성 검사가 추가되어, 모든 링크의 제목과 URL이 올바르게 입력되어야 저장할 수 있습니다.
  * 링크 입력란에 입력 가이드 문구가 조건부로 표시됩니다.

* **버그 수정**
  * 저장하기 버튼이 링크 입력값이 유효하지 않을 때 비활성화되어 잘못된 데이터 저장을 방지합니다.

* **스타일**
  * 일부 버튼 레이아웃의 불필요한 공백이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->