### PR TITLE
fix: 발송/미발송 예약 메일 Local Standard Time(Lst)로 수정

### DIFF
--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -44,11 +44,8 @@ export const formatDateLocalString = (date: Date, time: string): string => {
   return `${year}-${month}-${day}T${hour}:${minute}:00`;
 };
 
-export const formatUtcToKst = (utcString: string): string => {
-  const utcDate = new Date(utcString);
-
-  const kstTimestamp = utcDate.getTime() + 9 * 60 * 60 * 1000;
-  const kstDate = new Date(kstTimestamp);
+export const formatLst = (utcString: string): string => {
+  const kstDate = new Date(utcString);
 
   const year = kstDate.getFullYear();
   const month = (kstDate.getMonth() + 1).toString().padStart(2, '0');

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -45,13 +45,13 @@ export const formatDateLocalString = (date: Date, time: string): string => {
 };
 
 export const formatLst = (utcString: string): string => {
-  const kstDate = new Date(utcString);
+  const localDate = new Date(utcString);
 
-  const year = kstDate.getFullYear();
-  const month = (kstDate.getMonth() + 1).toString().padStart(2, '0');
-  const day = kstDate.getDate().toString().padStart(2, '0');
-  const hours = kstDate.getHours().toString().padStart(2, '0');
-  const minutes = kstDate.getMinutes().toString().padStart(2, '0');
+  const year = localDate.getFullYear();
+  const month = (localDate.getMonth() + 1).toString().padStart(2, '0');
+  const day = localDate.getDate().toString().padStart(2, '0');
+  const hours = localDate.getHours().toString().padStart(2, '0');
+  const minutes = localDate.getMinutes().toString().padStart(2, '0');
 
   return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
 };

--- a/src/widgets/dashboard/ui/email/SentMailCard.tsx
+++ b/src/widgets/dashboard/ui/email/SentMailCard.tsx
@@ -1,7 +1,7 @@
 import arrow from '../../../../../public/assets/dashboard/mail/Arrow.svg';
 import { useState } from 'react';
 import IconButton from '../../../../../design-system/ui/buttons/IconButton';
-import { formatUtcToKst } from '../../../../shared/lib/date';
+import { formatLst } from '../../../../shared/lib/date';
 import TertiaryButton from '../../../../../design-system/ui/buttons/TertiaryButton';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ReadEmailResponse } from '../../../../features/dashboard/model/email';
@@ -38,7 +38,7 @@ const SentMailCard = ({ mail, isPending = false, onClickDelete }: SentMailCardPr
             <p>{mail.title}</p>
           </div>
           <p className="text-sm text-placeholderText">
-            {formatUtcToKst(mail.reservationDate)}
+            {formatLst(mail.reservationDate)}
           </p>
         </div>
         <IconButton


### PR DESCRIPTION
## 발송/미발송 예약 메일 로컬 시간으로 포맷팅
<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/fc6eb966-1773-4c65-9946-2136f4bfb840" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 날짜 포맷팅 함수 이름이 변경되고, 구현이 간소화되어 지역 시간 기준으로 포맷팅됩니다.
  * 이메일 발송 내역 카드에서 새로운 날짜 포맷팅 함수를 사용하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->